### PR TITLE
fixed the order of episode and season since they were flipped

### DIFF
--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -66,7 +66,7 @@ class Calendar(object):
             e_data = {'airs_at': airs_date(episode.get('first_aired')),
                       'episode_ids': episode.get('episode').get('ids'),
                       'title': episode.get('episode', {}).get('title')}
-            self._calendar.append(TVEpisode(show, ep, season, **e_data))
+            self._calendar.append(TVEpisode(show, season, ep, **e_data))
         self._calendar = sorted(self._calendar, key=lambda x: x.airs_at)
 
 


### PR DESCRIPTION
when getting any kind of calendar the order of season # and episode # was flipped in the _build function