### PR TITLE
Remove unnecessary `__str__` magic methods.

### DIFF
--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -42,10 +42,9 @@ class Calendar(object):
         """Returns the length of the episodes list in this calendar"""
         return len(self._calendar)
 
-    def __str__(self):
-        """str representation of this Calendar"""
+    def __repr__(self):
+        """Representation of a :class:`Calendar`"""
         return pformat(self._calendar)
-    __repr__ = __str__
 
     @property
     def ext(self):

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -348,7 +348,6 @@ class Movie(object):
                                 year=self.year,
                                 **self.ids)]}
 
-    def __str__(self):
-        """String representation of a :class:`Movie`"""
+    def __repr__(self):
+        """Representation of a :class:`Movie`"""
         return '<Movie>: {}'.format(unicode_safe(self.title))
-    __repr__ = __str__

--- a/trakt/people.py
+++ b/trakt/people.py
@@ -98,10 +98,9 @@ class Person(object):
             self._tv_credits = TVCredits(**data)
         yield self._tv_credits
 
-    def __str__(self):
-        """String representation of a :class:`Person`"""
+    def __repr__(self):
+        """Representation of a :class:`Person`"""
         return '<Person>: {0}'.format(self.name)
-    __repr__ = __str__
 
 
 class ActingCredit(object):
@@ -112,14 +111,13 @@ class ActingCredit(object):
         self.character = character
         self.media = media
 
-    def __str__(self):
+    def __repr__(self):
+        """Representation of a :class:`ActingCredit`"""
         return '<{cls}> {character} - {title}'.format(
             cls=self.__class__.__name__,
             character=self.character,
             title=self.media.title
         )
-
-    __repr__ = __str__
 
 
 class CrewCredit(object):
@@ -130,14 +128,13 @@ class CrewCredit(object):
         self.job = job
         self.media = media
 
-    def __str__(self):
+    def __repr__(self):
+        """Representation of a :class:`CrewCredit`"""
         return '<{cls}> {job} - {title}'.format(
             cls=self.__class__.__name__,
             job=self.job,
             title=self.media.title
         )
-
-    __repr__ = __str__
 
 
 class Credits(object):

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -329,11 +329,9 @@ class TVShow(object):
             'title': self.title, 'year': self.year, 'ids': self.ids
         }]}
 
-    def __str__(self):
-        """Return a string representation of a :class:`TVShow`"""
+    def __repr__(self):
+        """Representation of a :class:`TVShow`"""
         return '<TVShow> {}'.format(unicode_safe(self.title))
-
-    __repr__ = __str__
 
 
 class TVSeason(object):
@@ -465,15 +463,14 @@ class TVSeason(object):
         show_obj.update({'seasons': [{'number': self.season}]})
         return {'shows': [show_obj]}
 
-    def __str__(self):
+    def __repr__(self):
+        """Representation of a :class:`TVSeason`"""
         title = ['<TVSeason>:', self.show, 'Season', self.season]
         title = map(str, title)
         return ' '.join(title)
 
     def __len__(self):
         return len(self._episodes)
-
-    __repr__ = __str__
 
 
 class TVEpisode(object):
@@ -669,8 +666,8 @@ class TVEpisode(object):
             }]
         }
 
-    def __str__(self):
+    def __repr__(self):
+        """Representation of a :class:`TVEpisode`"""
         return '<TVEpisode>: {} S{}E{} {}'.format(self.show, self.season,
                                                   self.number,
                                                   unicode_safe(self.title))
-    __repr__ = __str__

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -481,10 +481,9 @@ class User(object):
         """Unfollow this :class:`User`, if you already follow them"""
         unfollow(self.username)
 
-    def __str__(self):
-        """String representation of a :class:`User`"""
+    def __repr__(self):
+        """Representation of a :class:`User`"""
         return '<User>: {}'.format(unicode_safe(self.username))
-    __repr__ = __str__
 
 
 # get decorator issue workaround - "It's a little hacky"


### PR DESCRIPTION
When a `__repr__` is defined for a class and `__str__` is not, python will use the `__repr__` for the string.  This behaviour makes `__repr__ = __str__` unnecessary.