### PR TITLE
Added trakt oauth device authentication.

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -9,15 +9,18 @@ import os
 import requests
 import six
 import sys
+import time
 from collections import namedtuple
 from functools import wraps
+from requests.compat import urljoin
+from requests.exceptions import HTTPError
 from requests_oauthlib import OAuth2Session
 from trakt import errors
 
 __author__ = 'Jon Nappi'
 __all__ = ['Airs', 'Alias', 'Comment', 'Genre', 'get', 'delete', 'post', 'put',
            'init', 'BASE_URL', 'CLIENT_ID', 'CLIENT_SECRET', 'REDIRECT_URI',
-           'HEADERS', 'CONFIG_PATH', 'OAUTH_TOKEN', 'PIN_AUTH', 'OAUTH_AUTH',
+           'HEADERS', 'CONFIG_PATH', 'OAUTH_TOKEN', 'OAUTH_REFRESH', 'PIN_AUTH', 'OAUTH_AUTH',
            'AUTH_METHOD', 'APPLICATION_ID']
 
 #: The base url for the Trakt API. Can be modified to run against different
@@ -42,11 +45,17 @@ CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.pytrakt.json')
 #: Your personal Trakt.tv OAUTH Bearer Token
 OAUTH_TOKEN = api_key = None
 
+# Your OAUTH refresh token
+OAUTH_REFRESH = None
+
 #: Flag used to enable Trakt PIN authentication
 PIN_AUTH = 'PIN'
 
 #: Flag used to enable Trakt OAuth authentication
 OAUTH_AUTH = 'OAUTH'
+
+#: Flag used to enable Trakt OAuth device authentication
+DEVICE_AUTH = 'DEVICE'
 
 #: The currently enabled authentication method. Default is ``PIN_AUTH``
 AUTH_METHOD = PIN_AUTH
@@ -144,8 +153,8 @@ def oauth_auth(username, client_id=None, client_secret=None, store=False):
     CLIENT_ID, CLIENT_SECRET = client_id, client_secret
     HEADERS['trakt-api-key'] = CLIENT_ID
 
-    authorization_base_url = ''.join([BASE_URL, '/oauth/authorize'])
-    token_url = ''.join([BASE_URL, '/oauth/token'])
+    authorization_base_url = urljoin(BASE_URL, '/oauth/authorize')
+    token_url = urljoin(BASE_URL, '/oauth/token')
 
     # OAuth endpoints given in the API documentation
     oauth = OAuth2Session(CLIENT_ID, redirect_uri=REDIRECT_URI, state=None)
@@ -167,12 +176,140 @@ def oauth_auth(username, client_id=None, client_secret=None, store=False):
     return oauth.token['access_token']
 
 
+def get_device_code(client_id=None, client_secret=None):
+    """Generate a device code, used for device oauth authentication.
+
+    Trakt docs: https://trakt.docs.apiary.io/#reference/authentication-devices/device-code
+    :param client_id: Your Trakt OAuth Application's Client ID
+    :param client_secret: Your Trakt OAuth Application's Client Secret
+    :param store: Boolean flag used to determine if your trakt api auth data
+        should be stored locally on the system. Default is :const:`False` for
+        the security conscious
+    :return: Your OAuth device code.
+    """
+    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN
+    if client_id is None and client_secret is None:
+        client_id, client_secret = _get_client_info()
+    CLIENT_ID, CLIENT_SECRET = client_id, client_secret
+    HEADERS['trakt-api-key'] = CLIENT_ID
+
+    device_code_url = urljoin(BASE_URL, '/oauth/device/code')
+    headers = {'Content-Type': 'application/json'}
+    data = {"client_id": CLIENT_ID}
+
+    device_response = requests.post(device_code_url, json=data, headers=headers).json()
+    print('Your user code is: {user_code}, please navigate to {verification_url} to authenticate'.format(
+        user_code=device_response.get('user_code'), verification_url=device_response.get('verification_url')
+    ))
+
+    device_response['requested'] = time.time()
+    return device_response
+
+
+def get_device_token(device_code, client_id=None, client_secret=None, store=False):
+    """
+    Trakt docs: https://trakt.docs.apiary.io/#reference/authentication-devices/get-token
+    Response:
+    {
+      "access_token": "f22532274aa34ff6dee543d1e48619dc48f487908ed67195649936e5d3b41708",
+      "token_type": "bearer",
+      "expires_in": 7776000,
+      "refresh_token": "ace5848a4a2e22a656632accfb728ee4d6f595131ea5bf5554fef771b870c3da",
+      "scope": "public",
+      "created_at": 1519329051
+    }
+    :return: Information regarding the authentication polling.
+    :return type: dict
+    """
+    global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH
+    if client_id is None and client_secret is None:
+        client_id, client_secret = _get_client_info()
+    CLIENT_ID, CLIENT_SECRET = client_id, client_secret
+    HEADERS['trakt-api-key'] = CLIENT_ID
+
+    data = {
+        "code": device_code,
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET
+    }
+
+    headers = {
+        'Content-Type': 'application/json'
+    }
+
+    response = None
+    try:
+        response = requests.post('https://api.trakt.tv/oauth/device/token', json=data, headers=headers)
+        response.raise_for_status()
+    except HTTPError as error:
+        if response and getattr(response, 'status_code ') == 400:
+            raise errors.BadRequestException(error.message)
+
+    response = response.json()
+    OAUTH_TOKEN = response.get('access_token')
+    OAUTH_REFRESH = response.get('refresh_token')
+
+    if store:
+        _store(
+            CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET, OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH
+        )
+
+    return response
+
+
+def device_auth(client_id=None, client_secret=None, store=False):
+    """Process for authenticating using device authentication.
+
+    The function will attempt getting the device_id, and provide the user with a url and code. After getting the device
+    id, a timer is started to poll periodic for a successfull authentication. This is a blocking action, meaning you
+    will not be able to run any other code, while waiting for an access token.
+
+    If you want more control over the authentication flow, use the functions get_device_code and get_device_token.
+    Where poll_for_device_token will check if the "offline" authentication was successful.
+
+    :param client_id: Your Trakt OAuth Application's Client ID
+    :param client_secret: Your Trakt OAuth Application's Client Secret
+    :param store: Boolean flag used to determine if your trakt api auth data
+        should be stored locally on the system. Default is :const:`False` for
+        the security conscious
+    :return: A dict with the authentication result. Or False of authentication failed.
+    """
+    device_response = get_device_code(client_id=client_id, client_secret=client_secret)
+
+    authenticated = False
+    result = None
+    try:
+        result = get_device_token(device_response['device_code'], client_id=client_id,
+                                  client_secret=client_secret, store=store)
+    except errors.BadRequestException:
+        authenticated = False
+
+    while not authenticated and device_response.get('requested') and device_response['requested'] + device_response['expires_in'] > time.time():
+        time.sleep(device_response['interval'])
+        try:
+            result = get_device_token(device_response['device_code'], client_id=client_id,
+                                      client_secret=client_secret, store=store)
+        except errors.BadRequestException:
+            authenticated = False
+        else:
+            if result.get('access_token'):
+                authenticated = True
+
+    if authenticated:
+        print('Youve been succesfully authenticated. With access_token {access_token} '
+              'and refresh_token {refresh_token}'.format(
+                access_token=result['access_token'], refresh_token=result['refresh_token']
+              ))
+
+    return result
+
+
+auth_method = {PIN_AUTH: pin_auth, OAUTH_AUTH: oauth_auth, DEVICE_AUTH: device_auth}
+
+
 def init(*args, **kwargs):
     """Run the auth function specified by *AUTH_METHOD*"""
-    if AUTH_METHOD == PIN_AUTH:
-        return pin_auth(*args, **kwargs)
-    else:
-        return oauth_auth(*args, **kwargs)
+    return auth_method.get(AUTH_METHOD, PIN_AUTH)(*args, **kwargs)
 
 
 Airs = namedtuple('Airs', ['day', 'time', 'timezone'])
@@ -190,7 +327,7 @@ def _bootstrapped(f):
     """
     @wraps(f)
     def inner(*args, **kwargs):
-        global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN
+        global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH
         if (CLIENT_ID is None or CLIENT_SECRET is None) and \
                 os.path.exists(CONFIG_PATH):
             # Load in trakt API auth data fron CONFIG_PATH
@@ -203,6 +340,8 @@ def _bootstrapped(f):
                 CLIENT_SECRET = config_data.get('CLIENT_SECRET', None)
             if OAUTH_TOKEN is None:
                 OAUTH_TOKEN = config_data['OAUTH_TOKEN']
+            if OAUTH_REFRESH is None:
+                OAUTH_REFRESH = config_data['OAUTH_REFRESH']
 
             # For backwards compatability with trakt<=2.3.0
             if api_key is not None and OAUTH_TOKEN is None:

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -210,7 +210,8 @@ def get_device_code(client_id=None, client_secret=None):
     return device_response
 
 
-def get_device_token(device_code, client_id=None, client_secret=None, store=False):
+def get_device_token(device_code, client_id=None, client_secret=None,
+                     store=False):
     """
     Trakt docs: https://trakt.docs.apiary.io/#reference/
     authentication-devices/get-token
@@ -283,7 +284,8 @@ def device_auth(client_id=None, client_secret=None, store=False):
     :param store: Boolean flag used to determine if your trakt api auth data
         should be stored locally on the system. Default is :const:`False` for
         the security conscious
-    :return: A dict with the authentication result. Or False of authentication failed.
+    :return: A dict with the authentication result.
+    Or False of authentication failed.
     """
     device_response = get_device_code(client_id=client_id,
                                       client_secret=client_secret)
@@ -291,8 +293,10 @@ def device_auth(client_id=None, client_secret=None, store=False):
     authenticated = False
     result = None
     try:
-        result = get_device_token(device_response['device_code'], client_id=client_id,
-                                  client_secret=client_secret, store=store)
+        result = get_device_token(
+            device_response['device_code'], client_id=client_id,
+            client_secret=client_secret, store=store
+        )
     except errors.BadRequestException:
         authenticated = False
 

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -245,11 +245,11 @@ def get_device_token(device_code, client_id=None, client_secret=None,
 
     response = None
     try:
-        response = requests.post('https://api.trakt.tv/oauth/device/token',
+        response = requests.post(urljoin(BASE_URL, '/oauth/device/token'),
                                  json=data, headers=headers)
         response.raise_for_status()
     except HTTPError as error:
-        if response and getattr(response, 'status_code ') == 400:
+        if response and response.status_code == 400:
             raise errors.BadRequestException(error.message)
 
     response = response.json()

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -20,7 +20,7 @@ class TraktException(BaseException):
 
 
 class BadRequestException(TraktException):
-    """TraktException type to be raised when a 401 return code is recieved"""
+    """TraktException type to be raised when a 400 return code is recieved"""
     http_code = 400
     message = "Bad Request - request couldn't be parsed"
 


### PR DESCRIPTION
Added two functions that will allow you get a device_code and check for a successful oauth authentication.
Added one function that you can use to authenticate named device_auth.

Docs:
https://trakt.docs.apiary.io/#reference/authentication-devices/device-code/poll-for-the-access_token
https://trakt.docs.apiary.io/#reference/authentication-devices/get-token/poll-for-the-access_token

I've separated these, as the method to authenticate polls for the authentication (poll-for-the-access_token). And some applications (as ours) would rather not have this block any other processes.

I do have a few remarks regarding the code.
The existing authentication methods are not storing the REFRESH_TOKEN. Meaning that after three months you'll have to go through the same process. I've started adding it to the device oauth. But I still need to handle it, when re-authenticating.

Also i'm not finished yet with this one. Would like to clean up some.
But any early feedback is welcome.

## Usage:
```
import trakt.core
from trakt import init
trakt.core.AUTH_METHOD = trakt.core.DEVICE_AUTH
trakt.core.CLIENT_ID = 'Your client id'
trakt.core.CLIENT_SECRET = 'Your client secret'
init(trakt.core.CLIENT_ID, trakt.core.CLIENT_SECRET)
```
