### PR TITLE
Patch 2

### DIFF
--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -249,7 +249,8 @@ class TVShow(object):
             self._seasons = []
             for season in data:
                 extract_ids(season)
-                self._seasons.append(TVSeason(self.title, season.number, **season))
+                self._seasons.append(TVSeason(self.title, season.number,
+                                              **season))
         yield self._seasons
 
     @property

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -249,7 +249,7 @@ class TVShow(object):
             self._seasons = []
             for season in data:
                 extract_ids(season)
-                self._seasons.append(TVSeason(self.title, **season))
+                self._seasons.append(TVSeason(self.title, season.number, **season))
         yield self._seasons
 
     @property

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -249,7 +249,7 @@ class TVShow(object):
             self._seasons = []
             for season in data:
                 extract_ids(season)
-                self._seasons.append(TVSeason(self.title, season.number,
+                self._seasons.append(TVSeason(self.title, season['number'],
                                               **season))
         yield self._seasons
 


### PR DESCRIPTION
Fix the same season number showing in `TVShow.seasons` for each season
![screenshot from 2019-02-18 19-48-36](https://user-images.githubusercontent.com/35647358/52982901-9518b680-33b6-11e9-906e-3cff8902c008.png)
