### PR TITLE
Implemented Checkin, fixed Scrobble & Comment

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ PyTrakt is primarily written and maintained by [Jon Nappi](https://github.com/mo
 - [alexpayne482](https://github.com/alexpayne482)
 - [anongit](https://github.com/anongit)
 - [Forcide](https://github.com/forcide)
+- [Omja Das](https://github.com/omjadas)

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,6 @@ Sync
 - Create a comment class to facilitate
   - returning an instance when a comment is created, instead of None
   - add ability to update and delete comments
-- Add checkin support
 
 Movies
 ^^^^^^

--- a/tests/test_movies.py
+++ b/tests/test_movies.py
@@ -114,6 +114,17 @@ def test_dismiss_movie_recommendation():
     assert dismissed is None
 
 
+def test_movie_to_json_singular():
+    tron = Movie('Tron Legacy', year=2010)
+    expected = {'movie': {'title': tron.title,
+                          'year': 2010,
+                          'ids': {'imdb': 'tt1104001',
+                                  'slug': 'tron-legacy-2010',
+                                  'tmdb': 20526,
+                                  'trakt': 343}}}
+    assert tron.to_json_singular() == expected
+
+
 def test_movie_to_json():
     tron = Movie('Tron Legacy', year=2010)
     expected = {'movies': [{'title': tron.title,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -13,6 +13,9 @@ class FakeMedia(object):
     def __init__(self):
         self.ids = {}
 
+    def to_json_singular(self):
+        return {}
+
     def to_json(self):
         return {}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,7 @@ def test_now():
 
 
 def test_timestamp():
-    """verify that the trakt timestamp converer works as expected"""
+    """verify that the trakt timestamp converter works as expected"""
     meow = datetime.now()
     result = timestamp(meow)
     assert result.startswith(str(meow.year))

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -303,7 +303,7 @@ def device_auth(client_id=None, client_secret=None, store=False):
     }
 
     success_message = (
-        "You've been succesfully authenticated. "
+        "You've been successfully authenticated. "
         "With access_token {access_token} and refresh_token {refresh_token}"
     )
 
@@ -362,7 +362,7 @@ def _bootstrapped(f):
         global APPLICATION_ID
         if (CLIENT_ID is None or CLIENT_SECRET is None) and \
                 os.path.exists(CONFIG_PATH):
-            # Load in trakt API auth data fron CONFIG_PATH
+            # Load in trakt API auth data from CONFIG_PATH
             with open(CONFIG_PATH) as config_file:
                 config_data = json.load(config_file)
 
@@ -413,7 +413,7 @@ class Core(object):
         generator = f(*args, **kwargs)
         uri = next(generator)
         if not isinstance(uri, (str, tuple)):
-            # Allow properties to safetly yield arbitrary data
+            # Allow properties to safely yield arbitrary data
             return uri
         if isinstance(uri, tuple):
             uri, data = uri

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -20,43 +20,43 @@ class TraktException(BaseException):
 
 
 class BadRequestException(TraktException):
-    """TraktException type to be raised when a 400 return code is recieved"""
+    """TraktException type to be raised when a 400 return code is received"""
     http_code = 400
     message = "Bad Request - request couldn't be parsed"
 
 
 class OAuthException(TraktException):
-    """TraktException type to be raised when a 401 return code is recieved"""
+    """TraktException type to be raised when a 401 return code is received"""
     http_code = 401
     message = 'Unauthorized - OAuth must be provided'
 
 
 class ForbiddenException(TraktException):
-    """TraktException type to be raised when a 403 return code is recieved"""
+    """TraktException type to be raised when a 403 return code is received"""
     http_code = 403
     message = 'Forbidden - invalid API key or unapproved app'
 
 
 class NotFoundException(TraktException):
-    """TraktException type to be raised when a 404 return code is recieved"""
+    """TraktException type to be raised when a 404 return code is received"""
     http_code = 404
     message = 'Not Found - method exists, but no record found'
 
 
 class ConflictException(TraktException):
-    """TraktException type to be raised when a 409 return code is recieved"""
+    """TraktException type to be raised when a 409 return code is received"""
     http_code = 409
     message = 'Conflict - resource already created'
 
 
 class ProcessException(TraktException):
-    """TraktException type to be raised when a 422 return code is recieved"""
+    """TraktException type to be raised when a 422 return code is received"""
     http_code = 422
     message = 'Unprocessable Entity - validation errors'
 
 
 class RateLimitException(TraktException):
-    """TraktException type to be raised when a 429 return code is recieved"""
+    """TraktException type to be raised when a 429 return code is received"""
     http_code = 429
     message = 'Rate Limit Exceeded'
 

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -365,9 +365,9 @@ class Movie(object):
                       venue_name)
 
     def to_json(self):
-        return {'movies': [dict(title=self.title,
-                                year=self.year,
-                                **self.ids)]}
+        return {'movie': dict(title=self.title,
+                              year=self.year,
+                              **self.ids)}
 
     def __str__(self):
         """String representation of a :class:`Movie`"""

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -364,10 +364,15 @@ class Movie(object):
         checkin_media(self, app_version, app_date, message, sharing, venue_id,
                       venue_name)
 
-    def to_json(self):
+    def to_json_singular(self):
         return {'movie': dict(title=self.title,
                               year=self.year,
                               **self.ids)}
+
+    def to_json(self):
+        return {'movies': [dict(title=self.title,
+                                year=self.year,
+                                **self.ids)]}
 
     def __str__(self):
         """String representation of a :class:`Movie`"""

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -5,7 +5,8 @@ from trakt.core import Alias, Comment, Genre, get, delete
 from trakt.sync import (Scrobbler, comment, rate, add_to_history,
                         remove_from_history, add_to_watchlist,
                         remove_from_watchlist, add_to_collection,
-                        remove_from_collection, search)
+                        remove_from_collection, search, checkin_media,
+                        delete_checkin)
 from trakt.people import Person
 from trakt.utils import slugify, now, extract_ids, unicode_safe
 
@@ -342,6 +343,26 @@ class Movie(object):
             your plugin.
         """
         return Scrobbler(self, progress, app_version, app_date)
+
+    def checkin(self, app_version, app_date, message="", sharing={},
+                venue_id="", venue_name="", delete=False):
+        """Checkin this :class:`Movie` via the TraktTV API.
+
+        :param app_version:Version number of the media center, be as specific
+            as you can including nightly build number, etc. Used to help debug
+            your plugin.
+        :param app_date: Build date of the media center. Used to help debug
+            your plugin.
+        :param message: Message used for sharing. If not sent, it will use the
+            watching string in the user settings.
+        :param sharing: Control sharing to any connected social networks.
+        :param venue_id: Foursquare venue ID.
+        :param venue_name: Foursquare venue name.
+        """
+        if delete:
+            delete_checkin()
+        checkin_media(self, app_version, app_date, message, sharing, venue_id,
+                      venue_name)
 
     def to_json(self):
         return {'movies': [dict(title=self.title,

--- a/trakt/people.py
+++ b/trakt/people.py
@@ -91,7 +91,7 @@ class Person(object):
     @get
     def tv_credits(self):
         """Return a collection of TV Show credits that this :class:`Person` was
-        a cast or crew memeber on
+        a cast or crew member on
         """
         if self._tv_credits is None:
             data = yield self.ext_tv_credits

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -219,7 +219,7 @@ def checkin_media(media, app_version, app_date, message="", sharing={},
     """
     payload = dict(app_version=app_version, app_date=app_date, sharing=sharing,
                    message=message, venue_id=venue_id, venue_name=venue_name)
-    payload.update(media.to_json())
+    payload.update(media.to_json_singular())
     print(payload)
     yield "checkin", payload
 
@@ -287,7 +287,7 @@ class Scrobbler(object):
         """
         payload = dict(progress=self.progress, app_version=self.version,
                        date=self.date)
-        payload.update(self.media.to_json())
+        payload.update(self.media.to_json_singular())
         yield uri, payload
 
     def __enter__(self):

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -90,7 +90,7 @@ def remove_from_history(media):
 def remove_from_watchlist(media):
     """Remove a :class:`TVShow` from your watchlist
 
-    :param media: The :clas:`TVShow` to remove from your watchlist
+    :param media: The :class:`TVShow` to remove from your watchlist
     """
     yield 'sync/watchlist/remove', media.to_json()
 
@@ -265,7 +265,7 @@ class Scrobbler(object):
         """Handle actually posting the scrobbling data to trakt
 
         :param uri: The uri to post to
-        :param args: Any additional data to post to trakt alond with the
+        :param args: Any additional data to post to trakt along with the
             generic scrobbling data
         """
         payload = dict(progress=self.progress, app_version=self.version,
@@ -275,14 +275,14 @@ class Scrobbler(object):
 
     def __enter__(self):
         """Context manager support for `with Scrobbler` syntax. Begins
-        scrobbling the :class:`Scrobller`'s *media* object
+        scrobbling the :class:`Scrobbler`'s *media* object
         """
         self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager support for `with Scrobbler` syntax. Completes
-        scrobbling the :class:`Scrobller`'s *media* object
+        scrobbling the :class:`Scrobbler`'s *media* object
         """
         self.finish()
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -29,7 +29,7 @@ def comment(media, comment_body, spoiler=False, review=False):
     if not review and len(comment_body) > 200:
         review = True
     data = dict(comment=comment_body, spoiler=spoiler, review=review)
-    data.update(media.to_json())
+    data.update(media.to_json_singular())
     yield 'comments', data
 
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -2,7 +2,7 @@
 """This module contains Trakt.tv sync endpoint support functions"""
 from datetime import datetime
 
-from trakt.core import get, post
+from trakt.core import get, post, delete
 from trakt.utils import slugify, extract_ids, timestamp
 
 __author__ = 'Jon Nappi'
@@ -210,6 +210,23 @@ def search_by_id(query, id_type='imdb'):
             from trakt.people import Person
             results.append(Person(**d.pop('person')))
     yield results
+
+
+@post
+def checkin_media(media, app_version, app_date, message="", sharing={},
+                  venue_id="", venue_name=""):
+    """Checkin a media item
+    """
+    payload = dict(app_version=app_version, app_date=app_date, sharing=sharing,
+                   message=message, venue_id=venue_id, venue_name=venue_name)
+    payload.update(media.to_json())
+    print(payload)
+    yield "checkin", payload
+
+
+@delete
+def delete_checkin():
+    yield "checkin"
 
 
 class Scrobbler(object):

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -6,7 +6,8 @@ from trakt.core import Airs, Alias, Comment, Genre, delete, get
 from trakt.errors import NotFoundException
 from trakt.sync import (Scrobbler, rate, comment, add_to_collection,
                         add_to_watchlist, add_to_history, remove_from_history,
-                        remove_from_collection, remove_from_watchlist, search)
+                        remove_from_collection, remove_from_watchlist, search,
+                        checkin_media, delete_checkin)
 from trakt.utils import slugify, extract_ids, airs_date, unicode_safe
 from trakt.people import Person
 
@@ -658,6 +659,26 @@ class TVEpisode(object):
             your plugin.
         """
         return Scrobbler(self, progress, app_version, app_date)
+
+    def checkin(self, app_version, app_date, message="", sharing={},
+                venue_id="", venue_name="", delete=False):
+        """Checkin this :class:`TVEpisode` via the TraktTV API
+
+        :param app_version:Version number of the media center, be as specific
+            as you can including nightly build number, etc. Used to help debug
+            your plugin.
+        :param app_date: Build date of the media center. Used to help debug
+            your plugin.
+        :param message: Message used for sharing. If not sent, it will use the
+            watching string in the user settings.
+        :param sharing: Control sharing to any connected social networks.
+        :param venue_id: Foursquare venue ID.
+        :param venue_name: Foursquare venue name.
+        """
+        if delete:
+            delete_checkin()
+        checkin_media(self, app_version, app_date, message, sharing, venue_id,
+                      venue_name)
 
     def to_json(self):
         """Return this :class:`TVEpisode` as a trakt recognizable JSON object

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -680,6 +680,17 @@ class TVEpisode(object):
         checkin_media(self, app_version, app_date, message, sharing, venue_id,
                       venue_name)
 
+    def to_json_singular(self):
+        """Return this :class:`TVEpisode` as a trakt recognizable JSON object
+        """
+        return {
+            'episode': {
+                'ids': {
+                    'trakt': self.trakt
+                }
+            }
+        }
+
     def to_json(self):
         """Return this :class:`TVEpisode` as a trakt recognizable JSON object
         """

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -326,6 +326,11 @@ class TVShow(object):
     def remove_from_watchlist(self):
         remove_from_watchlist(self)
 
+    def to_json_singular(self):
+        return {'show': {
+            'title': self.title, 'year': self.year, 'ids': self.ids
+        }}
+
     def to_json(self):
         return {'shows': [{
             'title': self.title, 'year': self.year, 'ids': self.ids

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -412,7 +412,7 @@ class TVSeason(object):
     @get
     def _episode_getter(self, episode):
         """Recursive episode getter generator. Will attempt to get the
-        speicifed episode for this season, and if the requested episode wasn't
+        specified episode for this season, and if the requested episode wasn't
         found, then we return :const:`None` to indicate to the `episodes`
         property that we've already yielded all valid episodes for this season.
 


### PR DESCRIPTION
The existing `to_json()` methods for episodes and movies were not working for scrobbling or commenting and did not work for checkins, as Trakt expects the item to be singular (not lists) for those calls.

I created a `to_json_singular()` method which works correctly for checkin, scrobble, and comments. The `to_json()` method is still used for lists & collection & history
