### PR TITLE
Add next/last episode endpoint to `TVShow`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ PyTrakt is primarily written and maintained by [Jon Nappi](https://github.com/mo
 - [anongit](https://github.com/anongit)
 - [Forcide](https://github.com/forcide)
 - [Omja Das](https://github.com/omjadas)
+- [Peter Kovary](https://github.com/Faboor)

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -97,6 +97,7 @@ class TVShow(object):
         self.trakt = self.tmdb = self._aliases = self._comments = None
         self._images = self._people = self._ratings = self._translations = None
         self._seasons = None
+        self._last_episode = self._next_episode = None
         self.title = title
         self.slug = slug or slugify(self.title)
         if len(kwargs) > 0:
@@ -253,6 +254,28 @@ class TVShow(object):
                 self._seasons.append(TVSeason(self.title,
                                               season['number'], **season))
         yield self._seasons
+
+    @property
+    @get
+    def last_episode(self):
+        """Returns the most recently aired :class:`TVEpisode`. If no episode
+        is found, `None` will be returned.
+        """
+        if self._last_episode is None:
+            data = yield (self.ext + '/last_episode?extended=full')
+            self._last_episode = data and TVEpisode(show=self.title, **data)
+        yield self._last_episode
+
+    @property
+    @get
+    def next_episode(self):
+        """Returns the next scheduled to air :class:`TVEpisode`. If no episode
+        is found, `None` will be returned.
+        """
+        if self._next_episode is None:
+            data = yield (self.ext + '/next_episode?extended=full')
+            self._next_episode = data and TVEpisode(show=self.title, **data)
+        yield self._next_episode
 
     @property
     @get


### PR DESCRIPTION
Expose the [next](https://trakt.docs.apiary.io/#reference/shows/next-episode/get-next-episode) / [last](https://trakt.docs.apiary.io/#reference/shows/next-episode/get-last-episode) episode API endpoints in the `TVShow` class as properties.