### PR TITLE
User lists

### DIFF
--- a/tests/mock_data/users.json
+++ b/tests/mock_data/users.json
@@ -206,7 +206,15 @@
                 "item_count":5,
                 "comment_count":0,
                 "likes":0,
-                "ids":{"trakt":55,"slug":"star-wars-in-machete-order"}
+                "ids":{"trakt":55,"slug":"star-wars-in-machete-order"},
+                "user":{
+                    "username": "sean",
+                    "private": false,
+                    "name": "Sean Rudford",
+                    "vip": true,
+                    "vip_ep": true,
+                    "ids":{"slug":"sean"}
+                }
             },
             {
                 "name":"Vampires FTW",
@@ -221,7 +229,15 @@
                 "item_count":5,
                 "comment_count":0,
                 "likes":0,
-                "ids":{"trakt":52,"slug":"vampires-ftw"}
+                "ids":{"trakt":52,"slug":"vampires-ftw"},
+                "user":{
+                    "username": "sean",
+                    "private": false,
+                    "name": "Sean Rudford",
+                    "vip": true,
+                    "vip_ep": true,
+                    "ids":{"slug":"sean"}
+                }
             }
         ],
         "POST": {

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -295,6 +295,10 @@ class User(object):
             data = yield 'users/{username}/lists'.format(
                 username=self.username
             )
+            for ul in data:
+                if "user" in ul:
+                    # user will be replaced with the self User object
+                    del ul["user"]
             self._lists = [UserList(creator=self.username, user=self,
                            **extract_ids(ul)) for ul in data]
         yield self._lists


### PR DESCRIPTION
This removes the "user" entry from the API dict for `/users/[slug]/lists` so that it will properly
be replaced with the User self object. Fixes #113