### PR TITLE
Automatically refresh token after expiration

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -392,7 +392,7 @@ def _refresh_token(s):
         OAUTH_REFRESH = data.get("refresh_token")
         OAUTH_EXPIRES_AT = data.get("created_at") + data.get("expires_in")
         OAUTH_TOKEN_VALID = True
-        s.logger.dinfo("OAuth token successfully refreshed, valid until", datetime.fromtimestamp(OAUTH_EXPIRES_AT))
+        s.logger.info("OAuth token successfully refreshed, valid until", datetime.fromtimestamp(OAUTH_EXPIRES_AT))
         _store(
             CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,
             OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH,

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 from functools import wraps
 from requests.compat import urljoin
 from requests_oauthlib import OAuth2Session
+from datetime import datetime, timedelta
 from trakt import errors
 
 __author__ = 'Jon Nappi'
@@ -43,6 +44,12 @@ CONFIG_PATH = os.path.join(os.path.expanduser('~'), '.pytrakt.json')
 
 #: Your personal Trakt.tv OAUTH Bearer Token
 OAUTH_TOKEN = api_key = None
+
+# OAuth token validity checked
+OAUTH_TOKEN_VALID = None
+
+# Your OAUTH token expiration date
+OAUTH_EXPIRES_AT = None
 
 # Your OAUTH refresh token
 OAUTH_REFRESH = None
@@ -185,10 +192,13 @@ def oauth_auth(username, client_id=None, client_secret=None, store=False,
     # Fetch, assign, and return the access token
     oauth.fetch_token(token_url, client_secret=CLIENT_SECRET, code=oauth_pin)
     OAUTH_TOKEN = oauth.token['access_token']
+    OAUTH_REFRESH = oauth.token['refresh_token']
+    OAUTH_EXPIRES_AT = oauth.token["created_at"] + oauth.token["expires_in"]
 
     if store:
         _store(CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,
-               OAUTH_TOKEN=OAUTH_TOKEN)
+               OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH,
+               OAUTH_EXPIRES_AT=OAUTH_EXPIRES_AT)
     return OAUTH_TOKEN
 
 
@@ -263,11 +273,13 @@ def get_device_token(device_code, client_id=None, client_secret=None,
         data = response.json()
         OAUTH_TOKEN = data.get('access_token')
         OAUTH_REFRESH = data.get('refresh_token')
+        OAUTH_EXPIRES_AT = data.get("created_at") + data.get("expires_in")
 
         if store:
             _store(
                 CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,
-                OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH
+                OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH,
+                OAUTH_EXPIRES_AT=OAUTH_EXPIRES_AT
             )
 
     return response
@@ -350,6 +362,46 @@ Comment = namedtuple('Comment', ['id', 'parent_id', 'created_at', 'comment',
                                  'spoiler', 'review', 'replies', 'user',
                                  'updated_at', 'likes', 'user_rating'])
 
+def _validate_token(s):
+    """Check if current OAuth token has not expired"""
+    global OAUTH_TOKEN_VALID
+    current = datetime.utcnow()
+    expires_at = datetime.utcfromtimestamp(OAUTH_EXPIRES_AT)
+    if expires_at - current > timedelta(days=2):
+        OAUTH_TOKEN_VALID = True
+    else:
+        _refresh_token(s)
+
+def _refresh_token(s):
+    """Request Trakt API for a new valid OAuth token using refresh_token"""
+    global OAUTH_TOKEN, OAUTH_EXPIRES_AT, OAUTH_REFRESH, OAUTH_TOKEN_VALID
+    s.logger.info("OAuth token has expired, refreshing now...")
+    url = urljoin(BASE_URL, '/oauth/token')
+    data = {
+                'client_id': CLIENT_ID,
+                'client_secret': CLIENT_SECRET,
+                'refresh_token': OAUTH_REFRESH,
+                'redirect_uri': REDIRECT_URI,
+                'grant_type': 'refresh_token'
+            }
+    response = requests.post(url, json=data, headers=HEADERS)
+    s.logger.debug('RESPONSE [post] (%s): %s', url, str(response))
+    if response.status_code == 200:
+        data = response.json()
+        OAUTH_TOKEN = data.get("access_token")
+        OAUTH_REFRESH = data.get("refresh_token")
+        OAUTH_EXPIRES_AT = data.get("created_at") + data.get("expires_in")
+        OAUTH_TOKEN_VALID = True
+        s.logger.dinfo("OAuth token successfully refreshed, valid until", datetime.fromtimestamp(OAUTH_EXPIRES_AT))
+        _store(
+            CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,
+            OAUTH_TOKEN=OAUTH_TOKEN, OAUTH_REFRESH=OAUTH_REFRESH,
+            OAUTH_EXPIRES_AT=OAUTH_EXPIRES_AT
+        )
+    elif response.status_code == 401:
+        s.logger.debug("Rejected - Unable to refresh expired OAuth token, refresh_token is invalid")
+    elif response.status_code in s.error_map:
+        raise s.error_map[response.status_code]()
 
 def _bootstrapped(f):
     """Bootstrap your authentication environment when authentication is needed
@@ -358,7 +410,7 @@ def _bootstrapped(f):
     """
     @wraps(f)
     def inner(*args, **kwargs):
-        global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_REFRESH
+        global CLIENT_ID, CLIENT_SECRET, OAUTH_TOKEN, OAUTH_EXPIRES_AT, OAUTH_REFRESH
         global APPLICATION_ID
         if (CLIENT_ID is None or CLIENT_SECRET is None) and \
                 os.path.exists(CONFIG_PATH):
@@ -372,11 +424,16 @@ def _bootstrapped(f):
                 CLIENT_SECRET = config_data.get('CLIENT_SECRET', None)
             if OAUTH_TOKEN is None:
                 OAUTH_TOKEN = config_data.get('OAUTH_TOKEN', None)
+            if OAUTH_EXPIRES_AT is None:
+                OAUTH_EXPIRES_AT = config_data.get('OAUTH_EXPIRES_AT', None)
             if OAUTH_REFRESH is None:
                 OAUTH_REFRESH = config_data.get('OAUTH_REFRESH', None)
             if APPLICATION_ID is None:
                 APPLICATION_ID = config_data.get('APPLICATION_ID', None)
 
+            # Check token validity and refresh token if needed
+            if not OAUTH_TOKEN_VALID and OAUTH_EXPIRES_AT is not None and OAUTH_REFRESH is not None:
+                _validate_token(args[0])
             # For backwards compatability with trakt<=2.3.0
             if api_key is not None and OAUTH_TOKEN is None:
                 OAUTH_TOKEN = api_key


### PR DESCRIPTION
It is possible to use Trakt API to refresh access token automatically using `refresh_token`. This PR adds a function to do so.
It checks if OAuth access token has not expired, and request a new one if needed.
Trakt access token are valid only [during 3 months](https://trakt.docs.apiary.io/#reference/authentication-oauth/get-token).

closes #117 
closes https://github.com/Taxel/PlexTraktSync/issues/20