### PR TITLE
TraktException should inherit from Exception

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -11,7 +11,7 @@ __all__ = ['TraktException', 'BadRequestException', 'OAuthException',
            'TraktUnavailable']
 
 
-class TraktException(BaseException):
+class TraktException(Exception):
     """Base Exception type for trakt module"""
     http_code = message = None
 


### PR DESCRIPTION
As per the python [exceptions](https://docs.python.org/3/library/exceptions.html) docs, TraktException should inherit from Exception instead of BaseException.
This change fixes the HomeAssistant custom component so it doesn't kill HomeAssistant (all user code should expect Exception, nothing will catch TraktException if it's BaseException...)

Unfortunately I don't have a devenv set up, so couldn't test it, but I've found no other code depending on BaseException.