### PR TITLE
Update datetime.now calls to use timezone info

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -13,7 +13,7 @@ import time
 from collections import namedtuple
 from functools import wraps
 from requests_oauthlib import OAuth2Session
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from trakt import errors
 
 __author__ = 'Jon Nappi'
@@ -366,8 +366,8 @@ Comment = namedtuple('Comment', ['id', 'parent_id', 'created_at', 'comment',
 def _validate_token(s):
     """Check if current OAuth token has not expired"""
     global OAUTH_TOKEN_VALID
-    current = datetime.utcnow()
-    expires_at = datetime.utcfromtimestamp(OAUTH_EXPIRES_AT)
+    current = datetime.now(tz=timezone.utc)
+    expires_at = datetime.fromtimestamp(OAUTH_EXPIRES_AT, tz=timezone.utc)
     if expires_at - current > timedelta(days=2):
         OAUTH_TOKEN_VALID = True
     else:
@@ -396,7 +396,7 @@ def _refresh_token(s):
         OAUTH_TOKEN_VALID = True
         s.logger.info(
             "OAuth token successfully refreshed, valid until",
-            datetime.fromtimestamp(OAUTH_EXPIRES_AT)
+            datetime.fromtimestamp(OAUTH_EXPIRES_AT, tz=timezone.utc)
         )
         _store(
             CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module contains Trakt.tv sync endpoint support functions"""
-from datetime import datetime
+from datetime import datetime, timezone
 
 from trakt.core import get, post, delete
 from trakt.utils import slugify, extract_ids, timestamp
@@ -47,7 +47,7 @@ def rate(media, rating, rated_at=None):
         this rating was created
     """
     if rated_at is None:
-        rated_at = datetime.now()
+        rated_at = datetime.now(tz=timezone.utc)
 
     data = dict(rating=rating, rated_at=timestamp(rated_at))
     data.update(media.ids)
@@ -65,7 +65,7 @@ def add_to_history(media, watched_at=None):
         which this media item was viewed
     """
     if watched_at is None:
-        watched_at = datetime.now()
+        watched_at = datetime.now(tz=timezone.utc)
 
     data = dict(watched_at=timestamp(watched_at))
     data.update(media.ids)

--- a/trakt/utils.py
+++ b/trakt/utils.py
@@ -35,10 +35,7 @@ def airs_date(airs_at):
 def now():
     """Get the current day in the format expected by each :class:`Calendar`"""
     meow = datetime.now(tz=timezone.utc)
-    year = meow.year
-    month = meow.month if meow.month >= 10 else '0{}'.format(meow.month)
-    day = meow.day if meow.day >= 10 else '0{}'.format(meow.day)
-    return '{}-{}-{}'.format(year, month, day)
+    return meow.strftime("%Y-%m-%d")
 
 
 def timestamp(date_object):

--- a/trakt/utils.py
+++ b/trakt/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import unicodedata
-from datetime import datetime
+from datetime import datetime, timezone
 
 __author__ = 'Jon Nappi'
 __all__ = ['slugify', 'airs_date', 'now', 'timestamp', 'extract_ids']
@@ -34,7 +34,7 @@ def airs_date(airs_at):
 
 def now():
     """Get the current day in the format expected by each :class:`Calendar`"""
-    meow = datetime.now()
+    meow = datetime.now(tz=timezone.utc)
     year = meow.year
     month = meow.month if meow.month >= 10 else '0{}'.format(meow.month)
     day = meow.day if meow.day >= 10 else '0{}'.format(meow.day)


### PR DESCRIPTION
I noticed when I called `trakt.sync.add_to_history(movie)` (or `tv`), the time on trakt.tv was getting set in the past (the number of hours my current timezone is offset from GMT / UTC). Updated the defaults to use timezone-aware datetime logic. Timezone handling is confusing so I used [this as a reference](https://blog.ganssle.io/articles/2019/11/utcnow.html).

[Current utils code](https://github.com/moogar0880/PyTrakt/blob/2.14.1-release/trakt/utils.py#L27-L36) also drops timezone info for `airs_date`, but I couldn't figure out an elegant way to fix that.

Changes:
- update for `.now()` with `datetime.timezone` with timezone-aware datetimes
- change `utcnow() -> now(tz=timezone.utc)`
- change `utcfromtimestamp(...) -> fromtimestamp(..., tz=timezone.utc)`
- use `strftime` directly for string-formatting a datetime object