### PR TITLE
Update people.py

### DIFF
--- a/trakt/people.py
+++ b/trakt/people.py
@@ -66,6 +66,13 @@ class Person(object):
             except AttributeError as ae:
                 if not hasattr(self, '_' + key):
                     raise ae
+    @property
+    def ids(self):
+        """Accessor to the trakt, imdb, and tmdb ids, as well as the trakt.tv
+        slug
+        """
+        return {'ids': {'trakt': self.trakt, 'slug': self.slug,
+                        'imdb': self.imdb, 'tmdb': self.tmdb}}
 
     @property
     @get


### PR DESCRIPTION
added the ids accessor to the trakt, imdb, and tmdb ids, as well as the trakt.tv slug for People.

This allows to solve the problem when calling the User.add_items() functions that yielded an error when running this line:
``` 
people = [p.ids for p in items if isinstance(p, Person)]
``` 