### PR TITLE
Add http response to TraktException

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -409,7 +409,7 @@ def _refresh_token(s):
             "refresh_token is invalid"
         )
     elif response.status_code in s.error_map:
-        raise s.error_map[response.status_code]()
+        raise s.error_map[response.status_code](response)
 
 
 def load_config():
@@ -521,7 +521,7 @@ class Core(object):
                                         headers=HEADERS)
         self.logger.debug('RESPONSE [%s] (%s): %s', method, url, str(response))
         if response.status_code in self.error_map:
-            raise self.error_map[response.status_code]()
+            raise self.error_map[response.status_code](response)
         elif response.status_code == 204:  # HTTP no content
             return None
         json_data = json.loads(response.content.decode('UTF-8', 'ignore'))

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -15,6 +15,9 @@ class TraktException(Exception):
     """Base Exception type for trakt module"""
     http_code = message = None
 
+    def __init__(self, response=None):
+        self.response = response
+
     def __str__(self):
         return self.message
 


### PR DESCRIPTION
To be able to read the "Retry-After" value of a 429 http error ([trakt rate limit](https://trakt.docs.apiary.io/#introduction/rate-limiting) exceeded) the rised exception should give access to http response header.
This PR adds the http response to TraktException.