### PR TITLE
Add MethodNotAllowedException exception for 405 status code

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -8,7 +8,7 @@ __author__ = 'Jon Nappi'
 __all__ = ['TraktException', 'BadRequestException', 'OAuthException',
            'ForbiddenException', 'NotFoundException', 'ConflictException',
            'ProcessException', 'RateLimitException', 'TraktInternalException',
-           'TraktUnavailable']
+           'TraktUnavailable', 'MethodNotAllowedException']
 
 
 class TraktException(Exception):
@@ -44,6 +44,12 @@ class NotFoundException(TraktException):
     """TraktException type to be raised when a 404 return code is received"""
     http_code = 404
     message = 'Not Found - method exists, but no record found'
+
+
+class MethodNotAllowedException(TraktException):
+    """TraktException type to be raised when a 405 return code is received"""
+    http_code = 405
+    message = 'Method not Allowed'
 
 
 class ConflictException(TraktException):


### PR DESCRIPTION
I was debugging `ValueError` being thrown from `search_by_id`, which appeared to be `JSONDecodeError` (`JSONDecodeError` is subclass of `ValueError`) happening on decode of empty response (`''`).

```python
search = trakt.sync.search_by_id('264991/2/2', id_type='tvdb')
```