### PR TITLE
Add global session object for requests

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -69,6 +69,9 @@ AUTH_METHOD = PIN_AUTH
 #: The ID of the application to register with, when using PIN authentication
 APPLICATION_ID = None
 
+#: Global session to make requests with
+session = requests.Session()
+
 
 def _store(**kwargs):
     """Helper function used to store Trakt configurations at ``CONFIG_PATH``

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -138,7 +138,7 @@ def pin_auth(pin=None, client_id=None, client_secret=None, store=False):
             'client_id': CLIENT_ID,
             'client_secret': CLIENT_SECRET}
 
-    response = requests.post(''.join([BASE_URL, '/oauth/token']), data=args)
+    response = session.post(''.join([BASE_URL, '/oauth/token']), data=args)
     OAUTH_TOKEN = response.json().get('access_token', None)
 
     if store:
@@ -227,7 +227,7 @@ def get_device_code(client_id=None, client_secret=None):
     headers = {'Content-Type': 'application/json'}
     data = {"client_id": CLIENT_ID}
 
-    device_response = requests.post(device_code_url, json=data,
+    device_response = session.post(device_code_url, json=data,
                                     headers=headers).json()
     print('Your user code is: {user_code}, please navigate to '
           '{verification_url} to authenticate'.format(
@@ -268,7 +268,7 @@ def get_device_token(device_code, client_id=None, client_secret=None,
         "client_secret": CLIENT_SECRET
     }
 
-    response = requests.post(urljoin(BASE_URL, '/oauth/device/token'),
+    response = session.post(urljoin(BASE_URL, '/oauth/device/token'),
                              json=data)
 
     # We only get json on success.
@@ -389,7 +389,7 @@ def _refresh_token(s):
                 'redirect_uri': REDIRECT_URI,
                 'grant_type': 'refresh_token'
             }
-    response = requests.post(url, json=data, headers=HEADERS)
+    response = session.post(url, json=data, headers=HEADERS)
     s.logger.debug('RESPONSE [post] (%s): %s', url, str(response))
     if response.status_code == 200:
         data = response.json()

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -517,10 +517,10 @@ class Core(object):
         self.logger.debug('headers: %s', str(HEADERS))
         self.logger.debug('method, url :: %s, %s', method, url)
         if method == 'get':  # GETs need to pass data as params, not body
-            response = requests.request(method, url, params=data,
+            response = session.request(method, url, params=data,
                                         headers=HEADERS)
         else:
-            response = requests.request(method, url, data=json.dumps(data),
+            response = session.request(method, url, data=json.dumps(data),
                                         headers=HEADERS)
         self.logger.debug('RESPONSE [%s] (%s): %s', method, url, str(response))
         if response.status_code in self.error_map:

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -227,8 +227,8 @@ def get_device_code(client_id=None, client_secret=None):
     headers = {'Content-Type': 'application/json'}
     data = {"client_id": CLIENT_ID}
 
-    device_response = session.post(device_code_url, json=data,
-                                    headers=headers).json()
+    device_response = session.post(device_code_url,
+                                   json=data, headers=headers).json()
     print('Your user code is: {user_code}, please navigate to '
           '{verification_url} to authenticate'.format(
             user_code=device_response.get('user_code'),
@@ -268,8 +268,9 @@ def get_device_token(device_code, client_id=None, client_secret=None,
         "client_secret": CLIENT_SECRET
     }
 
-    response = session.post(urljoin(BASE_URL, '/oauth/device/token'),
-                             json=data)
+    response = session.post(
+        urljoin(BASE_URL, '/oauth/device/token'), json=data
+    )
 
     # We only get json on success.
     if response.status_code == 200:
@@ -517,11 +518,11 @@ class Core(object):
         self.logger.debug('headers: %s', str(HEADERS))
         self.logger.debug('method, url :: %s, %s', method, url)
         if method == 'get':  # GETs need to pass data as params, not body
-            response = session.request(method, url, params=data,
-                                        headers=HEADERS)
+            response = session.request(method, url, headers=HEADERS,
+                                       params=data)
         else:
-            response = session.request(method, url, data=json.dumps(data),
-                                        headers=HEADERS)
+            response = session.request(method, url, headers=HEADERS,
+                                       data=json.dumps(data))
         self.logger.debug('RESPONSE [%s] (%s): %s', method, url, str(response))
         if response.status_code in self.error_map:
             raise self.error_map[response.status_code](response)


### PR DESCRIPTION
The intent is to be able to override in client libraries with requests_cache for example:
- https://github.com/reclosedev/requests-cache/issues/289

----

```py
        trakt.core.session = CachedSession()
        trakt.init(client_id=client_id, client_secret=client_secret, store=True)

```