### PR TITLE
Fix "token refreshed" log message

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -399,8 +399,9 @@ def _refresh_token(s):
         OAUTH_EXPIRES_AT = data.get("created_at") + data.get("expires_in")
         OAUTH_TOKEN_VALID = True
         s.logger.info(
-            "OAuth token successfully refreshed, valid until",
-            datetime.fromtimestamp(OAUTH_EXPIRES_AT, tz=timezone.utc)
+            "OAuth token successfully refreshed, valid until {}".format(
+                datetime.fromtimestamp(OAUTH_EXPIRES_AT, tz=timezone.utc)
+            )
         )
         _store(
             CLIENT_ID=CLIENT_ID, CLIENT_SECRET=CLIENT_SECRET,


### PR DESCRIPTION
This PR fixes a mispelled info log message.

Error :
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/logging/__init__.py", line 1083, in emit
    msg = self.format(record)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 927, in format
    return fmt.format(record)
  File "/usr/local/lib/python3.9/logging/__init__.py", line 663, in format
    record.message = record.getMessage()
  File "/usr/local/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/local/lib/python3.9/site-packages/trakt/users.py", line 5, in <module>
    from trakt.movies import Movie
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 855, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/trakt/movies.py", line 23, in <module>
    def dismiss_recommendation(title):
  File "/usr/local/lib/python3.9/site-packages/trakt/core.py", line 453, in inner
    _validate_token(args[0])
  File "/usr/local/lib/python3.9/site-packages/trakt/core.py", line 374, in _validate_token
    _refresh_token(s)
  File "/usr/local/lib/python3.9/site-packages/trakt/core.py", line 397, in _refresh_token
    s.logger.info(
Message: 'OAuth token successfully refreshed, valid until'
Arguments: (datetime.datetime(2021, 9, 22, 2, 20, 2, tzinfo=datetime.timezone.utc),)
```