### PR TITLE
TVEpisode property 'show' must be the show title

### DIFF
--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -81,7 +81,7 @@ class Calendar(object):
                 'show_data': TVShow(**show_data)
             }
             self._calendar.append(
-                TVEpisode(show_data['trakt'], season, ep_num, **e_data)
+                TVEpisode(show_data['title'], season, ep_num, **e_data)
             )
         self._calendar = sorted(self._calendar, key=lambda x: x.airs_at)
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -286,7 +286,7 @@ def search_by_id(query, id_type='imdb', media_type=None, slugify_query=False):
             from trakt.tv import TVEpisode
             show = d.pop('show')
             extract_ids(d['episode'])
-            results.append(TVEpisode(show, **d['episode']))
+            results.append(TVEpisode(show.get('title', None), **d['episode']))
         elif 'movie' in d:
             from trakt.movies import Movie
             results.append(Movie(**d.pop('movie')))
@@ -333,7 +333,7 @@ def get_watchlist(list_type=None, sort=None):
             from trakt.tv import TVEpisode
             show = d.pop('show')
             extract_ids(d['episode'])
-            results.append(TVEpisode(show, **d['episode']))
+            results.append(TVEpisode(show.get('title', None), **d['episode']))
         elif 'movie' in d:
             from trakt.movies import Movie
             results.append(Movie(**d.pop('movie')))


### PR DESCRIPTION
The first argument `show` of **TVEpisode()** must be the title of the show.
I spotted 3 lines where it's not instantiated as expected.

Correct example in other parts of the code :
https://github.com/moogar0880/PyTrakt/blob/033f2ed37590621868bba6253ed5435e61e69171/trakt/sync.py#L223-L224
https://github.com/moogar0880/PyTrakt/blob/033f2ed37590621868bba6253ed5435e61e69171/trakt/users.py#L148-L149