### PR TITLE
Remove __all__ from errors module

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -474,11 +474,11 @@ class Core(object):
         self.logger = logging.getLogger('trakt.core')
 
         # Get all of our exceptions except the base exception
-        errs = [getattr(errors, att) for att in errors.__all__
-                if att != 'TraktException']
+        errs = [getattr(errors, att) for att in dir(errors)
+                if att != 'TraktException' and att[0] != '_']
 
         # Map HTTP response codes to exception types
-        self.error_map = {err.http_code: err for err in errs}
+        self.error_map = {err.http_code: err for err in errs if hasattr(err, 'http_code')}
 
     @staticmethod
     def _get_first(f, *args, **kwargs):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -5,10 +5,6 @@ guaranteed to have the application/json MIME type set.
 """
 
 __author__ = 'Jon Nappi'
-__all__ = ['TraktException', 'BadRequestException', 'OAuthException',
-           'ForbiddenException', 'NotFoundException', 'ConflictException',
-           'ProcessException', 'RateLimitException', 'TraktInternalException',
-           'TraktUnavailable', 'MethodNotAllowedException']
 
 
 class TraktException(Exception):


### PR DESCRIPTION
This is not needed since everything in the module is expected to be
exported.

Simplifies changes to the module, like: 
- https://github.com/moogar0880/PyTrakt/pull/163