### PR TITLE
Fix/Tests: Allow running tests from arbitary working dir

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,8 @@ from copy import deepcopy
 
 import trakt
 
-
-MOCK_DATA_DIR = os.path.abspath('tests/mock_data')
-
+TESTS_DIR = os.path.dirname(__file__)
+MOCK_DATA_DIR = os.path.join(TESTS_DIR, "mock_data")
 
 MOCK_DATA_FILES = [
     os.path.join(MOCK_DATA_DIR, 'calendars.json'),


### PR DESCRIPTION
PyCharm runs the tests from the directory the test itself resides.