### PR TITLE
[python-pytrakt] Tests: Print urls for what mock data is missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,11 @@ class MockCore(trakt.core.Core):
         # use a deepcopy of the mocked data to ensure clean responses on every
         # request. this prevents rewrites to JSON responses from persisting
         method_responses = deepcopy(self.mock_data).get(uri, {})
-        return method_responses.get(method.upper())
+        result = method_responses.get(method.upper())
+        if result is None:
+            print(f"Missing mock for {method.upper()} {trakt.core.BASE_URL}{uri}")
+
+        return result
 
 
 """Override utility functions from trakt.core to use an underlying MockCore


### PR DESCRIPTION
This makes it easy to understand if some mock data is missing:

```
Missing mock for GET https://api-v2launch.trakt.tv/shows/game-of-thrones/progress/collection
Missing mock for GET https://api-v2launch.trakt.tv/shows/game-of-thrones/progress/watched
```