### PR TITLE
Feature: Add Sync class with watched_shows method

### DIFF
--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -437,6 +437,23 @@ class Sync(object):
     def __init__(self):
         super(Sync, self).__init__()
 
+    @staticmethod
+    def _watched(watch_type):
+        uri = f'sync/watched/{watch_type}'
+
+        data = yield uri
+
+        yield data
+
+    @get
+    def watched_shows(self):
+        """
+        Returns all shows a user has watched sorted by most plays.
+
+        https://trakt.docs.apiary.io/#reference/sync/get-watched/get-watched
+        """
+        return self._watched('shows')
+
 
 class Scrobbler(object):
     """Scrobbling is a seemless and automated way to track what you're watching

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -431,6 +431,13 @@ def delete_checkin():
     yield "checkin"
 
 
+class Sync(object):
+    """Container for Sync operations"""
+
+    def __init__(self):
+        super(Sync, self).__init__()
+
+
 class Scrobbler(object):
     """Scrobbling is a seemless and automated way to track what you're watching
         in a media center. This class allows the media center to easily send


### PR DESCRIPTION
This is to carry methods to this library:
- https://github.com/Taxel/PlexTraktSync/blob/010c3479a898f31bbc093c38562f09373c3a7dbe/plextraktsync/pytrakt_extensions.py#L46-L50