### PR TITLE
[python-pytrakt] Add GitHub Actions workflow to publish to pypi

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,42 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: PyPI
+
+on:
+  workflow_dispatch: ~
+  release:
+    types: [published]
+  push:
+    tags:
+      - '*.*.*'
+
+env:
+  DEFAULT_PYTHON: 3.10
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.DEFAULT_PYTHON }}
+
+    - name: Install dependencies and build
+      run: |
+        python -m pip install --upgrade build
+        python -m build
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+
+# vim:ts=2:sw=2:et


### PR DESCRIPTION
This will create pip package and upload to pypi when git tag is pushed to GitHub.

Inspired from:
- https://github.com/Taxel/PlexTraktSync/pull/510

Docs:
- https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries


Needs to setup token `PYPI_TOKEN` as Secrets:
- https://pypi.org/help/#apitoken

Refs:
- https://github.com/moogar0880/PyTrakt/issues/199