### PR TITLE
[python-pytrakt] Feature: Throw BadResponseException on JSON decode errors

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -16,6 +16,7 @@ from functools import wraps
 from requests_oauthlib import OAuth2Session
 from datetime import datetime, timedelta, timezone
 from trakt import errors
+from trakt.errors import BadResponseException
 
 __author__ = 'Jon Nappi'
 __all__ = ['Airs', 'Alias', 'Comment', 'Genre', 'get', 'delete', 'post', 'put',
@@ -533,8 +534,8 @@ class Core(object):
 
         try:
             json_data = json.loads(response.content.decode('UTF-8', 'ignore'))
-        except JSONDecodeError:
-            raise errors.BadResponseException(response)
+        except JSONDecodeError as e:
+            raise BadResponseException(response, f"Unable to parse JSON: {e}")
 
         return json_data
 

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -5,6 +5,7 @@ trakt package
 import json
 import logging
 import os
+from json import JSONDecodeError
 from urllib.parse import urljoin
 
 import requests
@@ -529,7 +530,12 @@ class Core(object):
             raise self.error_map[response.status_code](response)
         elif response.status_code == 204:  # HTTP no content
             return None
-        json_data = json.loads(response.content.decode('UTF-8', 'ignore'))
+
+        try:
+            json_data = json.loads(response.content.decode('UTF-8', 'ignore'))
+        except JSONDecodeError:
+            raise errors.BadResponseException(response)
+
         return json_data
 
     def get(self, f):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -6,7 +6,13 @@ guaranteed to have the application/json MIME type set.
 
 __author__ = 'Jon Nappi'
 __all__ = [
+    # Base Exception
     'TraktException',
+
+    # Errors for use by PyTrakt
+    'BadResponseException',
+
+    # Exceptions by HTTP status code
     'BadRequestException',
     'OAuthException',
     'ForbiddenException',
@@ -30,6 +36,12 @@ class TraktException(Exception):
 
     def __str__(self):
         return self.message
+
+
+class BadResponseException(TraktException):
+    """TraktException type to be raised when json could not be decoded"""
+    http_code = -1
+    message = "Bad Response - Response could not be parsed"
 
 
 class BadRequestException(TraktException):

--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -43,6 +43,10 @@ class BadResponseException(TraktException):
     http_code = -1
     message = "Bad Response - Response could not be parsed"
 
+    def __init__(self, response=None, details=None):
+        super().__init__(response)
+        self.details = details
+
 
 class BadRequestException(TraktException):
     """TraktException type to be raised when a 400 return code is received"""


### PR DESCRIPTION
Many `JSONDecodeError` (from json module) are actually thrown because trakt.tv site responds with a status code that is not yet recognized by this library:

- https://github.com/Taxel/PlexTraktSync/issues?q=label%3A%22trakt+support%22+sort%3Aupdated-desc+is%3Aclosed+JSONDecodeError

Add fallback logic to be able to catch this specific error from applications.

Fixes https://github.com/moogar0880/PyTrakt/issues/146