### PR TITLE
[python-pytrakt] Refactor: Add IdsMixin to replace extract_ids() utility method

### DIFF
--- a/docs/movies.rst
+++ b/docs/movies.rst
@@ -15,8 +15,7 @@ block the specified movie from being shown in your recommended movies.
 ::
 
     >>> from trakt.movies import dismiss_recommendation
-    >>> dismiss_recommendation(imdb_id='tt3139072', title='Son of Batman',
-    ...                        year=2014)
+    >>> dismiss_recommendation('Son of Batman')
 
 
 This code snippet would prevent Son of Batman from appearing in your recommended

--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -4,7 +4,7 @@ from pprint import pformat
 from trakt.core import get
 from trakt.movies import Movie
 from trakt.tv import TVEpisode, TVShow
-from trakt.utils import extract_ids, now, airs_date
+from trakt.utils import now, airs_date
 
 __author__ = 'Jon Nappi'
 __all__ = ['Calendar', 'PremiereCalendar', 'MyPremiereCalendar',
@@ -72,7 +72,6 @@ class Calendar(object):
             first_aired = cal_item.get('first_aired')
             season = episode.get('season')
             ep_num = episode.get('number')
-            extract_ids(show_data)
             show_data.update(show_data)
             e_data = {
                 'airs_at': airs_date(first_aired),

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -12,15 +12,10 @@ class IdsMixin:
     This is replacement for extract_ids() utility method.
     """
 
+    __ids = ['imdb', 'slug', 'tmdb', 'trakt']
+
     def __init__(self):
-        self._ids = {
-            'tmdb': None,
-            'trakt': None,
-            'tvdb': None,
-            'slug': None,
-            'tvrage': None,
-        }
-        self.slug = None
+        self._ids = {}
 
     @property
     def ids(self):
@@ -28,13 +23,9 @@ class IdsMixin:
         Accessor to the trakt, imdb, and tmdb ids,
         as well as the trakt.tv slug
         """
+        ids = {k: getattr(self, k, None) for k in self.__ids}
         return {
-            'ids': {
-                'imdb': self.imdb,
-                'slug': self.slug,
-                'tmdb': self.tmdb,
-                'trakt': self.trakt,
-            }
+            'ids': ids
         }
 
     @property

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""Contains various MixIns"""
+
+__author__ = 'Jon Nappi, Elan Ruusamäe'

--- a/trakt/mixins.py
+++ b/trakt/mixins.py
@@ -2,3 +2,57 @@
 """Contains various MixIns"""
 
 __author__ = 'Jon Nappi, Elan Ruusamäe'
+
+
+class IdsMixin:
+    """
+    Provides Mixin to translate "ids" array
+    to appropriate provider ids in base class.
+
+    This is replacement for extract_ids() utility method.
+    """
+
+    def __init__(self):
+        self._ids = {
+            'tmdb': None,
+            'trakt': None,
+            'tvdb': None,
+            'slug': None,
+            'tvrage': None,
+        }
+        self.slug = None
+
+    @property
+    def ids(self):
+        """
+        Accessor to the trakt, imdb, and tmdb ids,
+        as well as the trakt.tv slug
+        """
+        return {
+            'ids': {
+                'imdb': self.imdb,
+                'slug': self.slug,
+                'tmdb': self.tmdb,
+                'trakt': self.trakt,
+            }
+        }
+
+    @property
+    def imdb(self):
+        return self._ids.get('imdb', None)
+
+    @property
+    def tmdb(self):
+        return self._ids.get('tmdb', None)
+
+    @property
+    def trakt(self):
+        return self._ids.get('trakt', None)
+
+    @property
+    def tvdb(self):
+        return self._ids.get('tvdb', None)
+
+    @property
+    def tvrage(self):
+        return self._ids.get('tvrage', None)

--- a/trakt/people.py
+++ b/trakt/people.py
@@ -1,23 +1,26 @@
 # -*- coding: utf-8 -*-
 """Interfaces to all of the People objects offered by the Trakt.tv API"""
 from trakt.core import get
+from trakt.mixins import IdsMixin
 from trakt.sync import search
-from trakt.utils import extract_ids, slugify
+from trakt.utils import slugify
 
 __author__ = 'Jon Nappi'
 __all__ = ['Person', 'ActingCredit', 'CrewCredit', 'Credits', 'MovieCredits',
            'TVCredits']
 
 
-class Person(object):
+class Person(IdsMixin):
     """A Class representing a trakt.tv Person such as an Actor or Director"""
     def __init__(self, name, slug=None, **kwargs):
-        super(Person, self).__init__()
+        super().__init__()
         self.name = name
-        self.biography = self.birthplace = self.tmdb_id = self.birthday = None
+        self.biography = self.birthplace = self.birthday = None
+        self.death = self.homepage = None
         self.job = self.character = self._images = self._movie_credits = None
         self._tv_credits = None
         self.slug = slug or slugify(self.name)
+        self.tmdb_id = None  # @deprecated: unused
 
         if len(kwargs) > 0:
             self._build(kwargs)
@@ -59,21 +62,12 @@ class Person(object):
         self._build(data)
 
     def _build(self, data):
-        extract_ids(data)
         for key, val in data.items():
             try:
                 setattr(self, key, val)
             except AttributeError as ae:
                 if not hasattr(self, '_' + key):
                     raise ae
-
-    @property
-    def ids(self):
-        """Accessor to the trakt, imdb, and tmdb ids, as well as the trakt.tv
-        slug
-        """
-        return {'ids': {'trakt': self.trakt, 'slug': self.slug,
-                        'imdb': self.imdb, 'tmdb': self.tmdb}}
 
     @property
     @get

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -220,7 +220,6 @@ def get_search_results(query, search_type=None, slugify_query=False):
         elif media_item['type'] == 'episode':
             from trakt.tv import TVEpisode
             show = media_item.pop('show')
-            extract_ids(media_item)
             result.media = TVEpisode(show.get('title', None),
                                      **media_item.pop('episode'))
         elif media_item['type'] == 'person':
@@ -286,7 +285,6 @@ def search_by_id(query, id_type='imdb', media_type=None, slugify_query=False):
         if 'episode' in d:
             from trakt.tv import TVEpisode
             show = d.pop('show')
-            extract_ids(d['episode'])
             results.append(TVEpisode(show.get('title', None), **d['episode']))
         elif 'movie' in d:
             from trakt.movies import Movie
@@ -333,7 +331,6 @@ def get_watchlist(list_type=None, sort=None):
         if 'episode' in d:
             from trakt.tv import TVEpisode
             show = d.pop('show')
-            extract_ids(d['episode'])
             results.append(TVEpisode(show.get('title', None), **d['episode']))
         elif 'movie' in d:
             from trakt.movies import Movie

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -215,7 +215,6 @@ def get_search_results(query, search_type=None, slugify_query=False):
             result.media = Movie(**media_item.pop('movie'))
         elif media_item['type'] == 'show':
             from trakt.tv import TVShow
-            extract_ids(media_item)
             result.media = TVShow(**media_item.pop('show'))
         elif media_item['type'] == 'episode':
             from trakt.tv import TVEpisode

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -209,21 +209,24 @@ def get_search_results(query, search_type=None, slugify_query=False):
     # need to import Scrobblers
     results = []
     for media_item in data:
-        extract_ids(media_item)
         result = SearchResult(media_item['type'], media_item['score'])
         if media_item['type'] == 'movie':
             from trakt.movies import Movie
+            extract_ids(media_item)
             result.media = Movie(**media_item.pop('movie'))
         elif media_item['type'] == 'show':
             from trakt.tv import TVShow
+            extract_ids(media_item)
             result.media = TVShow(**media_item.pop('show'))
         elif media_item['type'] == 'episode':
             from trakt.tv import TVEpisode
             show = media_item.pop('show')
+            extract_ids(media_item)
             result.media = TVEpisode(show.get('title', None),
                                      **media_item.pop('episode'))
         elif media_item['type'] == 'person':
             from trakt.people import Person
+            extract_ids(media_item)
             result.media = Person(**media_item.pop('person'))
         results.append(result)
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 from trakt.core import get, post, delete
-from trakt.utils import slugify, extract_ids, timestamp
+from trakt.utils import slugify, timestamp
 
 
 __author__ = 'Jon Nappi'
@@ -275,9 +275,6 @@ def search_by_id(query, id_type='imdb', media_type=None, slugify_query=False):
         uri = 'search/{source}/{query}?type={media_type}'.format(
             query=query, source=source, media_type=media_type)
     data = yield uri
-
-    for media_item in data:
-        extract_ids(media_item)
 
     results = []
     for d in data:

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -226,7 +226,6 @@ def get_search_results(query, search_type=None, slugify_query=False):
                                      **media_item.pop('episode'))
         elif media_item['type'] == 'person':
             from trakt.people import Person
-            extract_ids(media_item)
             result.media = Person(**media_item.pop('person'))
         results.append(result)
 

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -212,7 +212,6 @@ def get_search_results(query, search_type=None, slugify_query=False):
         result = SearchResult(media_item['type'], media_item['score'])
         if media_item['type'] == 'movie':
             from trakt.movies import Movie
-            extract_ids(media_item)
             result.media = Movie(**media_item.pop('movie'))
         elif media_item['type'] == 'show':
             from trakt.tv import TVShow

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -9,7 +9,7 @@ from trakt.sync import (Scrobbler, rate, comment, add_to_collection,
                         add_to_watchlist, add_to_history, remove_from_history,
                         remove_from_collection, remove_from_watchlist, search,
                         checkin_media, delete_checkin)
-from trakt.utils import slugify, extract_ids, airs_date
+from trakt.utils import slugify, airs_date
 from trakt.people import Person
 
 __author__ = 'Jon Nappi'
@@ -196,15 +196,15 @@ def anticipated_shows(page=1, limit=10, extended=None):
     yield [TVShow(**show['show']) for show in data]
 
 
-class TVShow(object):
+class TVShow(IdsMixin):
     """A Class representing a TV Show object."""
 
     def __init__(self, title='', slug=None, **kwargs):
-        super(TVShow, self).__init__()
+        super().__init__()
         self.media_type = 'shows'
-        self.top_watchers = self.top_episodes = self.year = self.tvdb = None
-        self.imdb = self.genres = self.certification = self.network = None
-        self.trakt = self.tmdb = self._aliases = self._comments = None
+        self.top_watchers = self.top_episodes = self.year = None
+        self.genres = self.certification = self.network = None
+        self._aliases = self._comments = None
         self._images = self._people = self._ratings = self._translations = None
         self._seasons = None
         self._last_episode = self._next_episode = None
@@ -218,6 +218,9 @@ class TVShow(object):
 
     @property
     def slug(self):
+        if self._ids.get('slug', None) is not None:
+            return self._ids['slug']
+
         if self._slug is not None:
             return self._slug
 
@@ -243,7 +246,6 @@ class TVShow(object):
         self._build(data)
 
     def _build(self, data):
-        extract_ids(data)
         for key, val in data.items():
             if hasattr(self, '_' + key):
                 setattr(self, '_' + key, val)
@@ -312,16 +314,6 @@ class TVShow(object):
     def crew(self):
         """All of the crew members that worked on this :class:`TVShow`"""
         return [p for p in self.people if getattr(p, 'job')]
-
-    @property
-    def ids(self):
-        """Accessor to the trakt, imdb, and tmdb ids, as well as the trakt.tv
-        slug
-        """
-        return {'ids': {
-            'trakt': self.trakt, 'slug': self.slug, 'imdb': self.imdb,
-            'tmdb': self.tmdb, 'tvdb': self.tvdb
-        }}
 
     @property
     @get

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -384,7 +384,6 @@ class TVShow(object):
             data = yield self.ext + '/seasons?extended=full'
             self._seasons = []
             for season in data:
-                extract_ids(season)
                 self._seasons.append(TVSeason(self.title,
                                               season['number'], **season))
         yield self._seasons
@@ -500,11 +499,11 @@ class TVShow(object):
     __repr__ = __str__
 
 
-class TVSeason(object):
+class TVSeason(IdsMixin):
     """Container for TV Seasons"""
 
     def __init__(self, show, season=1, slug=None, **kwargs):
-        super(TVSeason, self).__init__()
+        super().__init__()
         self.show = show
         self.season = season
         self.slug = slug or slugify(show)

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from trakt.core import Airs, Alias, Comment, Genre, delete, get
 from trakt.errors import NotFoundException
+from trakt.mixins import IdsMixin
 from trakt.sync import (Scrobbler, rate, comment, add_to_collection,
                         add_to_watchlist, add_to_history, remove_from_history,
                         remove_from_collection, remove_from_watchlist, search,
@@ -639,19 +640,19 @@ class TVSeason(object):
     __repr__ = __str__
 
 
-class TVEpisode(object):
+class TVEpisode(IdsMixin):
     """Container for TV Episodes"""
 
     def __init__(self, show, season, number=-1, **kwargs):
-        super(TVEpisode, self).__init__()
+        super().__init__()
         self.media_type = 'episodes'
         self.show = show
         self.season = season
         self.number = number
         self.overview = self.title = self.year = self.number_abs = None
         self.first_aired = self.last_updated = None
-        self.trakt = self.tmdb = self.tvdb = self.imdb = None
-        self.tvrage = self._stats = self._images = self._comments = None
+        self.runtime = None
+        self._stats = self._images = self._comments = None
         self._translations = self._ratings = None
         if len(kwargs) > 0:
             self._build(kwargs)
@@ -669,7 +670,6 @@ class TVEpisode(object):
 
     def _build(self, data):
         """Build this :class:`TVEpisode` object with the data in *data*"""
-        extract_ids(data)
         for key, val in data.items():
             if hasattr(self, '_' + key):
                 setattr(self, '_' + key, val)
@@ -715,15 +715,6 @@ class TVEpisode(object):
         :param year: Optional year to limit results to
         """
         return search(title, search_type='episode', year=year)
-
-    @property
-    def ids(self):
-        """Accessor to the trakt, imdb, and tmdb ids, as well as the trakt.tv
-        slug
-        """
-        return {'ids': {
-            'trakt': self.trakt, 'imdb': self.imdb, 'tmdb': self.tmdb
-        }}
 
     @property
     @get

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -138,9 +138,8 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                                           item_data['slug']))
             elif item_type == 'season':
                 show_data = item.pop('show')
-                extract_ids(show_data)
                 season = TVSeason(show_data['title'], item_data['number'],
-                                  show_data['slug'])
+                                  show_data['ids']['slug'])
                 self._items.append(season)
             elif item_type == 'episode':
                 show_data = item.pop('show')

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -130,9 +130,8 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
             item_type = item['type']
             item_data = item.pop(item_type)
             if item_type == 'movie':
-                extract_ids(item_data)
                 self._items.append(Movie(item_data['title'], item_data['year'],
-                                         item_data['slug']))
+                                         item_data['ids']['slug']))
             elif item_type == 'show':
                 extract_ids(item_data)
                 self._items.append(TVShow(item_data['title'],
@@ -336,7 +335,6 @@ class User(object):
             self._movie_watchlist = []
             for movie in data:
                 mov = movie.pop('movie')
-                extract_ids(mov)
                 self._movie_watchlist.append(Movie(**mov))
             yield self._movie_watchlist
         yield self._movie_watchlist
@@ -354,7 +352,6 @@ class User(object):
             self._movie_collection = []
             for movie in data:
                 mov = movie.pop('movie')
-                extract_ids(mov)
                 self._movie_collection.append(Movie(**mov))
         yield self._movie_collection
 
@@ -391,7 +388,6 @@ class User(object):
             self._watched_movies = []
             for movie in data:
                 movie_data = movie.pop('movie')
-                extract_ids(movie_data)
                 movie_data.update(movie)
                 self._watched_movies.append(Movie(**movie_data))
         yield self._watched_movies
@@ -432,7 +428,6 @@ class User(object):
         media_type = data.pop('type')
         if media_type == 'movie':
             movie_data = data.pop('movie')
-            extract_ids(movie_data)
             movie_data.update(data)
             yield Movie(**movie_data)
         else:  # media_type == 'episode'

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -5,7 +5,7 @@ from trakt.core import get, post, delete
 from trakt.movies import Movie
 from trakt.people import Person
 from trakt.tv import TVShow, TVSeason, TVEpisode
-from trakt.utils import slugify, extract_ids
+from trakt.utils import slugify
 
 __author__ = 'Jon Nappi'
 __all__ = ['User', 'UserList', 'Request', 'follow', 'get_all_requests',
@@ -133,9 +133,8 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                 self._items.append(Movie(item_data['title'], item_data['year'],
                                          item_data['ids']['slug']))
             elif item_type == 'show':
-                extract_ids(item_data)
                 self._items.append(TVShow(item_data['title'],
-                                          item_data['slug']))
+                                          item_data['ids']['slug']))
             elif item_type == 'season':
                 show_data = item.pop('show')
                 season = TVSeason(show_data['title'], item_data['number'],
@@ -315,7 +314,6 @@ class User(object):
             self._show_watchlist = []
             for show in data:
                 show_data = show.pop('show')
-                extract_ids(show_data)
                 show_data.update(show)
                 self._show_watchlist.append(TVShow(**show_data))
             yield self._show_watchlist
@@ -366,7 +364,6 @@ class User(object):
             self._show_collection = []
             for show in data:
                 s = show.pop('show')
-                extract_ids(s)
                 sh = TVShow(**s)
                 sh._seasons = [TVSeason(show=sh.title, **sea)
                                for sea in show.pop('seasons')]
@@ -403,7 +400,6 @@ class User(object):
             self._watched_shows = []
             for show in data:
                 show_data = show.pop('show')
-                extract_ids(show_data)
                 show_data.update(show)
                 self._watched_shows.append(TVShow(**show_data))
         yield self._watched_shows

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -150,9 +150,8 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                                     item_data['number'])
                 self._items.append(episode)
             elif item_type == 'person':
-                extract_ids(item_data)
                 self._items.append(Person(item_data['name'],
-                                          item_data['slug']))
+                                          item_data['ids']['slug']))
 
         yield self._items
 

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -144,7 +144,6 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                 self._items.append(season)
             elif item_type == 'episode':
                 show_data = item.pop('show')
-                extract_ids(show_data)
                 episode = TVEpisode(show_data['title'], item_data['season'],
                                     item_data['number'])
                 self._items.append(episode)
@@ -432,7 +431,6 @@ class User(object):
             yield Movie(**movie_data)
         else:  # media_type == 'episode'
             ep_data = data.pop('episode')
-            extract_ids(ep_data)
             sh_data = data.pop('show')
             ep_data.update(data, show=sh_data.get('title'))
             yield TVEpisode(**ep_data)

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -129,11 +129,12 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                 continue
             item_type = item['type']
             item_data = item.pop(item_type)
-            extract_ids(item_data)
             if item_type == 'movie':
+                extract_ids(item_data)
                 self._items.append(Movie(item_data['title'], item_data['year'],
                                          item_data['slug']))
             elif item_type == 'show':
+                extract_ids(item_data)
                 self._items.append(TVShow(item_data['title'],
                                           item_data['slug']))
             elif item_type == 'season':
@@ -149,6 +150,7 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
                                     item_data['number'])
                 self._items.append(episode)
             elif item_type == 'person':
+                extract_ids(item_data)
                 self._items.append(Person(item_data['name'],
                                           item_data['slug']))
 


### PR DESCRIPTION
Extracting the "ids" on each response is tedious, and such duplication results users being confused:
- https://github.com/moogar0880/PyTrakt/issues/78#issuecomment-1013671336
- https://github.com/moogar0880/PyTrakt/issues/158#issuecomment-1013670394

Also, the existing extraction is inconsistent (Not applied for TVShow and Movie in this example):
- https://github.com/moogar0880/PyTrakt/blob/8a6d4f168a858447014fb4c2c0efceb47b30ebb7/trakt/sync.py#L331-L342

This will make the ids extraction automatic, and prevent updating the attributes directly.

Additionally it came out that properties like `tmdb_id`, `imdb_id`, `trakt_id` are unused. they are initialized as `None` in the constructor but never any other value. these are commented with `@deprecated` and are to be removed in 4.x.

- [x] Person
- [x] Movie
- [x] Calendar
- [x] SearchResult
- [x] TVShow
- [x] TVEpisode
- [x] TVSeason
- [x] UserList

TODO:
- [ ] rebase after https://github.com/moogar0880/PyTrakt/pull/187