### PR TITLE
[python-pytrakt] Cleanup: Drop classes extending from object

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -10,7 +10,7 @@ from trakt.sync import (comment, rate, add_to_history, add_to_watchlist,
 
 
 
-class FakeMedia(object):
+class FakeMedia:
     """Mock media type object to use with mock sync requests"""
     media_type = 'fake'
 

--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -12,7 +12,7 @@ __all__ = ['Calendar', 'PremiereCalendar', 'MyPremiereCalendar',
            'MySeasonCalendar', 'MovieCalendar', 'MyMovieCalendar']
 
 
-class Calendar(object):
+class Calendar:
     """Base :class:`Calendar` type serves as a foundation for other Calendar
     types
     """

--- a/trakt/core.py
+++ b/trakt/core.py
@@ -441,7 +441,7 @@ def load_config():
             APPLICATION_ID = config_data.get('APPLICATION_ID', None)
 
 
-class Core(object):
+class Core:
     """This class contains all of the functionality required for interfacing
     with the Trakt.tv API
     """

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -81,7 +81,7 @@ Release = namedtuple('Release', ['country', 'certification', 'release_date',
                                  'note', 'release_type'])
 
 
-class Movie(object):
+class Movie:
     """A Class representing a Movie object"""
     def __init__(self, title, year=None, slug=None, **kwargs):
         super(Movie, self).__init__()

--- a/trakt/people.py
+++ b/trakt/people.py
@@ -9,7 +9,7 @@ __all__ = ['Person', 'ActingCredit', 'CrewCredit', 'Credits', 'MovieCredits',
            'TVCredits']
 
 
-class Person(object):
+class Person:
     """A Class representing a trakt.tv Person such as an Actor or Director"""
     def __init__(self, name, slug=None, **kwargs):
         super(Person, self).__init__()
@@ -112,7 +112,7 @@ class Person(object):
     __repr__ = __str__
 
 
-class ActingCredit(object):
+class ActingCredit:
     """An individual credit for a :class:`Person` who played a character in a
     Movie or TV Show
     """
@@ -130,7 +130,7 @@ class ActingCredit(object):
     __repr__ = __str__
 
 
-class CrewCredit(object):
+class CrewCredit:
     """An individual crew credit for a :class:`Person` who had an off-screen
     job on a Movie or a TV Show
     """
@@ -148,7 +148,7 @@ class CrewCredit(object):
     __repr__ = __str__
 
 
-class Credits(object):
+class Credits:
     """A base type representing a :class:`Person`'s credits for Movies or TV
     Shows
     """

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -431,7 +431,7 @@ def delete_checkin():
     yield "checkin"
 
 
-class Scrobbler(object):
+class Scrobbler:
     """Scrobbling is a seemless and automated way to track what you're watching
         in a media center. This class allows the media center to easily send
         events that correspond to starting, pausing, stopping or finishing
@@ -504,7 +504,7 @@ class Scrobbler(object):
         self.finish()
 
 
-class SearchResult(object):
+class SearchResult:
     """A SearchResult is an individual result item from the trakt.tv search
     API. It wraps a single media entity whose type is indicated by the type
     field.

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -195,7 +195,7 @@ def anticipated_shows(page=1, limit=10, extended=None):
     yield [TVShow(**show['show']) for show in data]
 
 
-class TVShow(object):
+class TVShow:
     """A Class representing a TV Show object."""
 
     def __init__(self, title='', slug=None, **kwargs):
@@ -499,7 +499,7 @@ class TVShow(object):
     __repr__ = __str__
 
 
-class TVSeason(object):
+class TVSeason:
     """Container for TV Seasons"""
 
     def __init__(self, show, season=1, slug=None, **kwargs):
@@ -639,7 +639,7 @@ class TVSeason(object):
     __repr__ = __str__
 
 
-class TVEpisode(object):
+class TVEpisode:
     """Container for TV Episodes"""
 
     def __init__(self, show, season, number=-1, **kwargs):

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -200,7 +200,7 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
         yield uri.format(username=slugify(self.creator), id=self.trakt)
 
 
-class User(object):
+class User:
     """A Trakt.tv User"""
     def __init__(self, username, **kwargs):
         super(User, self).__init__()


### PR DESCRIPTION
This is not needed for Python3 as the "old style" classes don't exist and inheritance from object is implicit.

- https://stackoverflow.com/questions/15374857/should-all-python-classes-extend-object
- http://docs.python.org/release/2.5.2/ref/node33.html