### PR TITLE
[python-pytrakt] Cleanup: Remove old (python<3.0) super constructor syntax

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ MOCK_DATA_FILES = [
 
 class MockCore(trakt.core.Core):
     def __init__(self, *args, **kwargs):
-        super(MockCore, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mock_data = {}
         for mock_file in MOCK_DATA_FILES:
             with open(mock_file, encoding='utf-8') as f:

--- a/trakt/calendar.py
+++ b/trakt/calendar.py
@@ -26,7 +26,7 @@ class Calendar(object):
         :param days: Number of days for this :class:`Calendar`. Defaults to 7
             days
         """
-        super(Calendar, self).__init__()
+        super().__init__()
         self.date = date or now()
         self.days = days
         self._calendar = []

--- a/trakt/movies.py
+++ b/trakt/movies.py
@@ -84,7 +84,7 @@ Release = namedtuple('Release', ['country', 'certification', 'release_date',
 class Movie(object):
     """A Class representing a Movie object"""
     def __init__(self, title, year=None, slug=None, **kwargs):
-        super(Movie, self).__init__()
+        super().__init__()
         self.media_type = 'movies'
         self.title = title
         self.year = int(year) if year is not None else year

--- a/trakt/people.py
+++ b/trakt/people.py
@@ -12,7 +12,7 @@ __all__ = ['Person', 'ActingCredit', 'CrewCredit', 'Credits', 'MovieCredits',
 class Person(object):
     """A Class representing a trakt.tv Person such as an Actor or Director"""
     def __init__(self, name, slug=None, **kwargs):
-        super(Person, self).__init__()
+        super().__init__()
         self.name = name
         self.biography = self.birthplace = self.tmdb_id = self.birthday = None
         self.job = self.character = self._images = self._movie_credits = None

--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -448,7 +448,7 @@ class Scrobbler(object):
         :param app_version: The media center application version
         :param app_date: The date that *app_version* was released
         """
-        super(Scrobbler, self).__init__()
+        super().__init__()
         self.progress, self.version = progress, app_version
         self.media, self.date = media, app_date
         if self.progress > 0:

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -199,7 +199,7 @@ class TVShow(object):
     """A Class representing a TV Show object."""
 
     def __init__(self, title='', slug=None, **kwargs):
-        super(TVShow, self).__init__()
+        super().__init__()
         self.media_type = 'shows'
         self.top_watchers = self.top_episodes = self.year = self.tvdb = None
         self.imdb = self.genres = self.certification = self.network = None
@@ -503,7 +503,7 @@ class TVSeason(object):
     """Container for TV Seasons"""
 
     def __init__(self, show, season=1, slug=None, **kwargs):
-        super(TVSeason, self).__init__()
+        super().__init__()
         self.show = show
         self.season = season
         self.slug = slug or slugify(show)
@@ -643,7 +643,7 @@ class TVEpisode(object):
     """Container for TV Episodes"""
 
     def __init__(self, show, season, number=-1, **kwargs):
-        super(TVEpisode, self).__init__()
+        super().__init__()
         self.media_type = 'episodes'
         self.show = show
         self.season = season

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -69,7 +69,7 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
     """A list created by a Trakt.tv :class:`User`"""
 
     def __init__(self, *args, **kwargs):
-        super(UserList, self).__init__()
+        super().__init__()
         self._items = list()
 
     def __iter__(self, *args, **kwargs):
@@ -203,7 +203,7 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
 class User(object):
     """A Trakt.tv User"""
     def __init__(self, username, **kwargs):
-        super(User, self).__init__()
+        super().__init__()
         self.username = username
         self._calendar = self._last_activity = self._watching = None
         self._movies = self._movie_collection = self._movies_watched = None


### PR DESCRIPTION
```py
class C(B):
    def method(self, arg):
        super().method(arg)    # This does the same thing as:
                               # super(C, self).method(arg)
```

- https://docs.python.org/3/library/functions.html#super
- https://stackoverflow.com/questions/576169/understanding-python-super-with-init-methods