### PR TITLE
Cleanup: Undo _get renaming

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -100,7 +100,7 @@ class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
 
     @classmethod
     @get
-    def _get(cls, title, creator):
+    def get(cls, title, creator):
         """Returns a single custom :class:`UserList`
 
         :param title: Name of the list.
@@ -494,5 +494,5 @@ class User(object):
     __repr__ = __str__
 
 
-# get decorator issue workaround - "It's a little hacky"
-UserList.get = UserList._get
+# @deprecated remove in 4.0
+UserList._get = UserList.get


### PR DESCRIPTION
No need to rename `get` method to `_get`. This might have been an issue in older Python (2.x?)

This restores original symbol and for not to break API, the _get is aliased now. 

The `_get` aliases are to be dropped in 4.x

- [ ] `trakt/calendar.py:62:    def _get(self):`
- [ ] `trakt/movies.py:119:    def _get(self):`
- [ ] `trakt/people.py:57:    def _get(self):`
- [ ] `trakt/tv.py:238:    def _get(self):`
- [ ] `trakt/tv.py:519:    def _get(self):`
- [ ] `trakt/tv.py:663:    def _get(self):`
- [x] `trakt/users.py:225:    def _get(self):`