### PR TITLE
[python-pytrakt] Feature: Add Bad Gateway exception

### DIFF
--- a/trakt/errors.py
+++ b/trakt/errors.py
@@ -17,6 +17,7 @@ __all__ = [
     'LockedUserAccountException',
     'RateLimitException',
     'TraktInternalException',
+    'TraktBadGateway',
     'TraktUnavailable',
 ]
 
@@ -90,6 +91,12 @@ class TraktInternalException(TraktException):
     """TraktException type to be raised when a 500 error is raised"""
     http_code = 500
     message = 'Internal Server Error'
+
+
+class TraktBadGateway(TraktException):
+    """TraktException type to be raised when a 502 error is raised"""
+    http_code = 502
+    message = 'Trakt Unavailable - Bad Gateway'
 
 
 class TraktUnavailable(TraktException):


### PR DESCRIPTION
This ensures 502 responses don't get json decode exceptions


```
  File "/python-3.10.1/lib/python3.10/site-packages/trakt/core.py", line 533, in _handle_request
    json_data = json.loads(response.content.decode('UTF-8', 'ignore'))
  File "/usr/local/Cellar/python@3.10/3.10.1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python@3.10/3.10.1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python@3.10/3.10.1/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```