### PR TITLE
[python-pytrakt] Privacy: Don't log headers to protect privacy

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -516,7 +516,6 @@ class Core(object):
         self.logger.debug('%s: %s', method, url)
         HEADERS['trakt-api-key'] = CLIENT_ID
         HEADERS['Authorization'] = 'Bearer {0}'.format(OAUTH_TOKEN)
-        self.logger.debug('headers: %s', str(HEADERS))
         self.logger.debug('method, url :: %s, %s', method, url)
         if method == 'get':  # GETs need to pass data as params, not body
             response = session.request(method, url, headers=HEADERS,


### PR DESCRIPTION
Scenario, where need to really debug HTTP headers, are perhaps when developing this library. This is never useful for end-users and could cause leaking the tokens when sharing logs:

refs:
- https://github.com/Taxel/PlexTraktSync/issues/758#issuecomment-1025186047