### PR TITLE
[python-pytrakt] fix season number in show_collection

### DIFF
--- a/trakt/users.py
+++ b/trakt/users.py
@@ -372,7 +372,8 @@ class User(object):
                 s = show.pop('show')
                 extract_ids(s)
                 sh = TVShow(**s)
-                sh._seasons = [TVSeason(show=sh.title, **sea)
+                sh._seasons = [TVSeason(show=sh.title,
+                               season=sea['number'], **sea)
                                for sea in show.pop('seasons')]
                 self._show_collection.append(sh)
         yield self._show_collection


### PR DESCRIPTION
In Users, the **show_collection()** function fetches all collected seasons as seasons 1.

Here : https://github.com/moogar0880/PyTrakt/blob/8a6d4f168a858447014fb4c2c0efceb47b30ebb7/trakt/users.py#L375-L376

Same as:
- https://github.com/moogar0880/PyTrakt/issues/98

And the fix was:
- https://github.com/moogar0880/PyTrakt/pull/100

fixes #76