### PR TITLE
[python-pytrakt] Value 'type' added to Userlist

### DIFF
--- a/tests/mock_data/users.json
+++ b/tests/mock_data/users.json
@@ -47,6 +47,7 @@
                     "name":"Star Wars in NEW machete order",
                     "description":"Some descriptive text",
                     "privacy":"private",
+                    "type":"personal",
                     "display_numbers":true,
                     "allow_comments":false,
                     "updated_at":"2014-10-11T17:00:54.000Z",
@@ -188,7 +189,7 @@
             {"type":"show","show":{"title":"Breaking Bad","year":2008,"ids":{"trakt":1,"slug":"breaking-bad","tvdb":81189,"imdb":"tt0903747","tmdb":1396,"tvrage":18164}},"comment":{"id":199,"comment":"Skyler, I AM THE DANGER.","spoiler":false,"review":false,"parent_id":0,"created_at":"2015-02-18T06:02:30.000Z","replies":0,"likes":0,"user_rating":10,"user":{"username":"justin","private":false,"name":"Justin N.","vip":true,"vip_ep":false}}},
             {"type":"season","season":{"number":1,"ids":{"trakt":3958,"tvdb":274431,"tmdb":60394,"tvrage":38049}},"show":{"title":"Gotham","year":2014,"ids":{"trakt":869,"slug":"gotham","tvdb":274431,"imdb":"tt3749900","tmdb":60708,"tvrage":38049}},"comment":{"id":220,"comment":"Kicking off season 1 for a new Batman show.","spoiler":false,"review":false,"parent_id":0,"created_at":"2015-04-21T06:53:25.000Z","replies":0,"likes":0,"user_rating":8,"user":{"username":"justin","private":false,"name":"Justin N.","vip":true,"vip_ep":false}}},
             {"type":"episode","episode":{"season":1,"number":1,"title":"Jim Gordon","ids":{"trakt":63958,"tvdb":4768720,"imdb":"tt3216414","tmdb":975968,"tvrage":1065564827}},"show":{"title":"Gotham","year":2014,"ids":{"trakt":869,"slug":"gotham","tvdb":274431,"imdb":"tt3749900","tmdb":60708,"tvrage":38049}},"comment":{"id":229,"comment":"Is this the OC?","spoiler":false,"review":false,"parent_id":0,"created_at":"2015-04-21T15:42:31.000Z","replies":1,"likes":0,"user_rating":7,"user":{"username":"justin","private":false,"name":"Justin N.","vip":true,"vip_ep":false}}},
-            {"type":"list","list":{"name":"Star Wars","description":"The complete Star Wars saga!","privacy":"public","display_numbers":false,"allow_comments":true,"updated_at":"2015-04-22T22:01:39.000Z","item_count":8,"comment_count":0,"likes":0,"ids":{"trakt":51,"slug":"star-wars"}},"comment":{"id":268,"comment":"May the 4th be with you!","spoiler":false,"review":false,"parent_id":0,"created_at":"2014-12-08T17:34:51.000Z","replies":0,"likes":0,"user_rating":null,"user":{"username":"justin","private":false,"name":"Justin N.","vip":true,"vip_ep":false}}}
+            {"type":"list","list":{"name":"Star Wars","description":"The complete Star Wars saga!","privacy":"public","type":"personal","display_numbers":false,"allow_comments":true,"updated_at":"2015-04-22T22:01:39.000Z","item_count":8,"comment_count":0,"likes":0,"ids":{"trakt":51,"slug":"star-wars"}},"comment":{"id":268,"comment":"May the 4th be with you!","spoiler":false,"review":false,"parent_id":0,"created_at":"2014-12-08T17:34:51.000Z","replies":0,"likes":0,"user_rating":null,"user":{"username":"justin","private":false,"name":"Justin N.","vip":true,"vip_ep":false}}}
         ]
     },
     "users/sean/lists": {
@@ -197,6 +198,7 @@
                 "name":"Star Wars in machete order",
                 "description":"Some descriptive text",
                 "privacy":"public",
+                "type":"personal",
                 "display_numbers":true,
                 "allow_comments":true,
                 "sort_by": "rank",
@@ -220,6 +222,7 @@
                 "name":"Vampires FTW",
                 "description":"These suck, but in a good way!",
                 "privacy":"public",
+                "type":"personal",
                 "display_numbers":false,
                 "allow_comments":true,
                 "sort_by": "rank",
@@ -244,6 +247,7 @@
             "name":"Star Wars in machete order",
             "description":"Some descriptive text",
             "privacy":"public",
+            "type":"personal",
             "display_numbers":true,
             "allow_comments":true,
             "sort_by": "rank",
@@ -261,6 +265,7 @@
             "name":"Star Wars in machete order",
             "description":"Some descriptive text",
             "privacy":"public",
+            "type":"personal",
             "display_numbers":true,
             "allow_comments":true,
             "sort_by": "rank",
@@ -277,6 +282,7 @@
             "name":"Star Wars in NEW machete order",
             "description":"Some descriptive text",
             "privacy":"private",
+            "type":"personal",
             "display_numbers":true,
             "allow_comments":false,
             "sort_by": "rank",

--- a/trakt/users.py
+++ b/trakt/users.py
@@ -61,8 +61,9 @@ def unfollow(user_name):
 
 
 class UserList(namedtuple('UserList', ['name', 'description', 'privacy',
-                                       'display_numbers', 'allow_comments',
-                                       'sort_by', 'sort_how', 'created_at',
+                                       'type', 'display_numbers',
+                                       'allow_comments', 'sort_by',
+                                       'sort_how', 'created_at',
                                        'updated_at', 'item_count',
                                        'comment_count', 'likes', 'trakt',
                                        'slug', 'user', 'creator'])):


### PR DESCRIPTION
There's been an [update](https://apiblog.trakt.tv/api-changelog-2022-b62be006dd68) of Trakt API on 14 June 2022 adding a `type` value to lists :
> Each list object contains a type value set to personal or official.

This PR adds this `type` value to Userlist class to comply with trakt API update.

fixes #205 