### PR TITLE
[python-pytrakt] Add show_id attribute to TVEpisode found from search

### DIFF
--- a/trakt/sync.py
+++ b/trakt/sync.py
@@ -221,6 +221,7 @@ def get_search_results(query, search_type=None, slugify_query=False):
             from trakt.tv import TVEpisode
             show = media_item.pop('show')
             result.media = TVEpisode(show.get('title', None),
+                                     show_id=show['ids'].get('trakt'),
                                      **media_item.pop('episode'))
         elif media_item['type'] == 'person':
             from trakt.people import Person
@@ -286,7 +287,9 @@ def search_by_id(query, id_type='imdb', media_type=None, slugify_query=False):
             from trakt.tv import TVEpisode
             show = d.pop('show')
             extract_ids(d['episode'])
-            results.append(TVEpisode(show.get('title', None), **d['episode']))
+            results.append(TVEpisode(show.get('title', None),
+                                     show_id=show['ids'].get('trakt'),
+                                     **d.pop('episode')))
         elif 'movie' in d:
             from trakt.movies import Movie
             results.append(Movie(**d.pop('movie')))

--- a/trakt/tv.py
+++ b/trakt/tv.py
@@ -694,8 +694,11 @@ class TVEpisode(object):
 
     @property
     def ext(self):
+        show_id = getattr(self, "show_id", None)
+        if not show_id:
+            show_id = slugify(self.show)
         return 'shows/{id}/seasons/{season}/episodes/{episode}'.format(
-            id=slugify(self.show), season=self.season, episode=self.number
+            id=show_id, season=self.season, episode=self.number
         )
 
     @property


### PR DESCRIPTION
Actually, to get the show of a **TVEpisode** we only have show name (`self.show`) which is not reliable because some shows have the same name.
The show trakt id is more reliable than show name because it is unique.
This PR adds `show_id` attribute to **TVEpisode** built from search request and uses it in further API requests instead of slug built from show name.

__Example :__  [Top Boy](https://trakt.tv/shows/top-boy) and [Top Boy 2019](https://trakt.tv/shows/top-boy-2019)
A TVEpisode from [Top Boy 2019](https://trakt.tv/shows/top-boy-2019) uses slug `top-boy` (made from `slugify(self.show)` ) instead of `top-boy-2019` to fetch data from trakt api. Therefore data received is wrong.