### PR TITLE
Update to BASE_URL to point to updated API

### DIFF
--- a/trakt/core.py
+++ b/trakt/core.py
@@ -25,7 +25,7 @@ __all__ = ['Airs', 'Alias', 'Comment', 'Genre', 'get', 'delete', 'post', 'put',
 
 #: The base url for the Trakt API. Can be modified to run against different
 #: Trakt.tv environments
-BASE_URL = 'https://api-v2launch.trakt.tv/'
+BASE_URL = 'https://api.trakt.tv/'
 
 #: The Trakt.tv OAuth Client ID for your OAuth Application
 CLIENT_ID = None


### PR DESCRIPTION
> The API host name http://api-v2launch.trakt.tv will be removed on February 1. 
> 
> This has been deprecated since 2017. This will only affect very old apps and they need to use http://api.trakt.tv to continue working beyond February 1.
> 

[Source](https://twitter.com/traktapi/status/1742976564567106019)